### PR TITLE
SI: Set 'Accept' header to the integrity metadata's content type. (bug #6)

### DIFF
--- a/specs/subresourceintegrity/index.html
+++ b/specs/subresourceintegrity/index.html
@@ -547,6 +547,13 @@ stated otherwise, it is <code>indeterminate</code>.</p>
             <ol>
               <li>Set <var>response</var>&#8217;s integrity state to <code>pending</code>.</li>
               <li>Include a <code>Cache-Control</code> header whose value is &#8220;no-transform&#8221;.</li>
+              <li>If <var>request</var>&#8217;s integrity metadata contains a content
+type:
+                <ol>
+                  <li>Set <var>request</var>&#8217;s <code>Accept</code> header value to the value
+of <var>request</var>&#8217;s integrity metadata&#8217;s content type.</li>
+                </ol>
+              </li>
             </ol>
           </li>
         </ol>

--- a/specs/subresourceintegrity/spec.markdown
+++ b/specs/subresourceintegrity/spec.markdown
@@ -416,6 +416,10 @@ to enable the rest of this specification's work:
 
         1.  Set <var>response</var>'s integrity state to `pending`.
         2.  Include a `Cache-Control` header whose value is "no-transform".
+        3.  If <var>request</var>'s integrity metadata contains a content
+            type:
+            1.  Set <var>request</var>'s `Accept` header value to the value
+                of <var>request</var>'s integrity metadata's content type.
 
 4.  Add the following step before step #1 of the handling of 401 status
     codes for both "basic fetch" and "CORS fetch with preflight" algorithms:


### PR DESCRIPTION
This is intended to close bug #6. WDYT, @devd @mozfreddyb ?
