### PR TITLE
Use `hash-value` instead of `base64-value`

### DIFF
--- a/specs/content-security-policy/index.src.html
+++ b/specs/content-security-policy/index.src.html
@@ -636,7 +636,7 @@ Link Defaults: dom-core-ls (interface) event
       <dfn>hash-value</dfn>        = <a>base64-value</a>
       <dfn>nonce-source</dfn>      = "'nonce-" <a>nonce-value</a> "'"
       <dfn>hash-algo</dfn>         = "sha256" / "sha384" / "sha512"
-      <dfn>hash-source</dfn>       = "'" <a>hash-algo</a> "-" <a>base64-value</a> "'"
+      <dfn>hash-source</dfn>       = "'" <a>hash-algo</a> "-" <a>hash-value</a> "'"
       <dfn>scheme-part</dfn>       = &lt;scheme production from <a href="http://tools.ietf.org/html/rfc3986#section-3.1">RFC 3986, section 3.1</a>&gt;
       <dfn>host-part</dfn>         = "*" / [ "*." ] 1*<a>host-char</a> *( "." 1*<a>host-char</a> )
       <dfn>host-char</dfn>         = ALPHA / DIGIT / "-"


### PR DESCRIPTION
for consistency with `nonce-value`.
