### PR TITLE
CSP: port-part may have multiple digits

### DIFF
--- a/specs/content-security-policy/index.html
+++ b/specs/content-security-policy/index.html
@@ -840,7 +840,7 @@ Content-Security-Policy: <a data-link-type=dfn href=#connect-src title=connect-s
 <dfn data-dfn-type=dfn data-noexport="" id=host-part>host-part<a class=self-link href=#host-part></a></dfn>         = "*" / [ "*." ] 1*<a data-link-type=dfn href=#host-char title=host-char>host-char</a> *( "." 1*<a data-link-type=dfn href=#host-char title=host-char>host-char</a> )
 <dfn data-dfn-type=dfn data-noexport="" id=host-char>host-char<a class=self-link href=#host-char></a></dfn>         = ALPHA / DIGIT / "-"
 <dfn data-dfn-type=dfn data-noexport="" id=path-part>path-part<a class=self-link href=#path-part></a></dfn>         = &lt;path production from <a href=http://tools.ietf.org/html/rfc3986#section-3.3>RFC 3986, section 3.3</a>&gt;
-<dfn data-dfn-type=dfn data-noexport="" id=port-part>port-part<a class=self-link href=#port-part></a></dfn>         = ":" ( 1*DIGIT / "*" )
+<dfn data-dfn-type=dfn data-noexport="" id=port-part>port-part<a class=self-link href=#port-part></a></dfn>         = ":" ( *DIGIT / "*" )
 </pre>
 
 <p>If the policy contains a <code><a data-link-type=dfn href=#nonce-source title=nonce-source>nonce-source</a></code> expression, the


### PR DESCRIPTION
`port-part` is currently defined as `":" ( 1*DIGIT / "*" )`. Obviously, a port may be any natural number up to 65535, so I've changed it to `*DIGIT`, similar to the [definition of "port" in defined in RFC 3986](http://tools.ietf.org/html/rfc3986#section-3.2.3).
