### PR TITLE
Fix old digest attribute

### DIFF
--- a/specs/subresourceintegrity/index.html
+++ b/specs/subresourceintegrity/index.html
@@ -1505,7 +1505,7 @@ variants are more difficult to mitigate. Consider the following:</p>
           <li>
             <p>An attacker lures Alice to a page containing the following code:</p>
 
-            <pre class="example highlight"><code>&lt;script src="http://evil.com/evil.js" digest="ni://sha-256;123...789"&gt;
+            <pre class="example highlight"><code>&lt;script src="http://evil.com/evil.js" integrity="ni://sha-256;123...789"&gt;
 </code></pre>
           </li>
           <li>
@@ -1516,7 +1516,7 @@ variants are more difficult to mitigate. Consider the following:</p>
 <code>bank.com</code>, the attacker may still be able to exploit an XSS vulnerability
 in <code>bank.com</code> which allows the injection of:</p>
 
-            <pre class="example highlight"><code>&lt;script src="http://bank.com/awesome.js" digest="ni://sha-256;123...789"&gt;
+            <pre class="example highlight"><code>&lt;script src="http://bank.com/awesome.js" integrity="ni://sha-256;123...789"&gt;
 </code></pre>
 
             <p>Since the script appears to come from <code>bank.com</code>, CSP allows it, even though

--- a/specs/subresourceintegrity/spec.markdown
+++ b/specs/subresourceintegrity/spec.markdown
@@ -1253,7 +1253,7 @@ variants are more difficult to mitigate. Consider the following:
 
 1.  An attacker lures Alice to a page containing the following code:
 
-        <script src="http://evil.com/evil.js" digest="ni://sha-256;123...789">
+        <script src="http://evil.com/evil.js" integrity="ni://sha-256;123...789">
     {:.example.highlight}
 
 2.  Alice's user agent loads `evil.js`, and stores it in her cache.
@@ -1262,7 +1262,7 @@ variants are more difficult to mitigate. Consider the following:
     `bank.com`, the attacker may still be able to exploit an XSS vulnerability
     in `bank.com` which allows the injection of:
 
-        <script src="http://bank.com/awesome.js" digest="ni://sha-256;123...789">
+        <script src="http://bank.com/awesome.js" integrity="ni://sha-256;123...789">
     {:.example.highlight}
 
     Since the script appears to come from `bank.com`, CSP allows it, even though


### PR DESCRIPTION
I _think_ this example never got revised to the `integrity=` attribute.

cc @mikewest 
