### PR TITLE
Added support for web manifests (closes #29)

### DIFF
--- a/specs/content-security-policy/index.src.html
+++ b/specs/content-security-policy/index.src.html
@@ -2243,7 +2243,7 @@ At Risk: [[#directive-child-src]]
     <h3 id="directive-manifest-src"><code>manifest-src</code></h3>
 
     The <code><dfn>manifest-src</dfn></code> directive restricts which 
-    <a spec="appmanifest">manifests</a> the user agent may apply to the protected 
+    [[!APPMANIFEST]] the user agent may apply to the protected 
     resource. The syntax for the name and value of the directive are described by 
     the following ABNF grammar:
 
@@ -2256,18 +2256,6 @@ At Risk: [[#directive-child-src]]
     <a title="parse a source list">parsing the <code>manifest-src</code>
     directive's value as a source list</a> if the policy contains an
     explicit <code>manifest-src</code>, or otherwise to the <a>default sources</a>.
-
-    If <code>'unsafe-inline'</code> is <strong>not</strong> in the
-    list of <a>allowed manifest sources</a>, or if at least one
-    <code><a>nonce-source</a></code> or <code><a>hash-source</a></code>
-    is present in the list of <a>allowed manifest sources</a>:
-
-    <ul>
-      <li>Whenever the user agent would apply manifest from a
-      <code><a element>link</a></code> attribute, instead the user agent
-      <code>MUST</code> ignore the manifest, <em>and</em> MUST <a>report a
-      violation</a>.</li>
-    </ul>
 
     Whenever the user agent <a>fetches</a> a URI in the course of one of the
     following activities, if the URI does not
@@ -2283,31 +2271,6 @@ At Risk: [[#directive-child-src]]
       <code>manifest</code> or attempting to obtain the well-known manifest.
       </li>
     </ul>
-    
-    <section class="informative">
-      <h4 id="manifest-src-nonce-usage">
-        Nonce usage for <code><a element>link</a></code> elements
-      </h4>
-
-      <em>This section is not normative.</em>
-
-      See the <a href="#script-src-nonce-usage"><code>script-src</code>
-      nonce usage information</a> for detail; the application of nonces
-      to <code><a element>link</a></code> elements is similar enough to avoid
-      repetition here.
-    </section>
-    <section class="informative">
-      <h4 id="manifest-src-hash-usage">
-        Hash usage for <code><a element>link</a></code> elements
-      </h4>
-
-      <em>This section is not normative.</em>
-
-      See the <a href="#script-src-hash-usage"><code>script-src</code>
-      hash usage information</a> for detail; the application of hashes
-      to <code><a element>link</a></code> elements is similar enough to avoid
-      repetition here.
-    </section>
   </section>
 
 <!--


### PR DESCRIPTION
Proposed is based on style-src's text. Both Chrome and Gecko need this. 

See: https://code.google.com/p/chromium/issues/detail?id=409996
See: https://bugzilla.mozilla.org/show_bug.cgi?id=1089255
