### PR TITLE
Fix sha-256 hash name in example

### DIFF
--- a/specs/subresourceintegrity/spec.markdown
+++ b/specs/subresourceintegrity/spec.markdown
@@ -806,7 +806,7 @@ Note that this will cover _only_ downloads triggered explicitly by adding a
 `download` attribute to an `a` element. Such a link might look like the following:
 
     <a href="https://example.com/file.zip"
-       integrity="ni:///sha256;skjdsfkafinqfb...ihja_gqg?ct=application/octet-stream"
+       integrity="ni:///sha-256;skjdsfkafinqfb...ihja_gqg?ct=application/octet-stream"
        download>Download!</a>
 {:.example.highlight}
 </div>


### PR DESCRIPTION
Update example to use hash name consistent with other examples.

Though, its still unclear to me if `sha-256` is what is actually going to be implemented. Chrome Canary only supports `sha256`.

/cc @mikewest 
