### PR TITLE
Remove trailing equal signs from the sha-512 examples

### DIFF
--- a/specs/subresourceintegrity/spec.markdown
+++ b/specs/subresourceintegrity/spec.markdown
@@ -192,7 +192,8 @@ are encouraged to optimize.
 
 This section defines several terms used throughout the document.
 
-The term <dfn>digest</dfn> refers to the base64url-encoded result of
+The term <dfn>digest</dfn> refers to the base64url-encoded (with
+any trailing U+003D EQUALS SIGN (`=`) characters removed) result of
 executing a cryptographic hash function on an arbitrary block of data.
 
 A <dfn>secure channel</dfn> is any communication mechanism that the user


### PR DESCRIPTION
As per step 4 of "Apply algorithm to resource", the base64 encoding
of hashes are not supposed to have trailing equal signs.
