### PR TITLE
Label the three components of metadata

### DIFF
--- a/specs/subresourceintegrity/spec.markdown
+++ b/specs/subresourceintegrity/spec.markdown
@@ -254,9 +254,9 @@ used when fetching the resource.
 To verify the integrity of a resource, a user agent requires <dfn>integrity
 metadata</dfn>, which consists of the following pieces of information:
 
-* cryptographic hash function
-* [digest][]
-* the resource's MIME type
+* cryptographic hash function ("alg")
+* [digest][] ("val")
+* the resource's MIME type ("type")
 
 The hash function and digest MUST be provided in order to validate a
 resource's integrity. The MIME type SHOULD be provided, as it mitigates the


### PR DESCRIPTION
Include the labels used in the reference algorithms to refer to
these three components of the integrity metadata.
