### PR TITLE
Mention the one thing that integrity protects against on insecure origins

### DIFF
--- a/specs/subresourceintegrity/spec.markdown
+++ b/specs/subresourceintegrity/spec.markdown
@@ -721,9 +721,10 @@ in general.
 origin against a compromise of the server where an external resources is
 hosted. Network attackers can alter the digest in-flight (or remove it
 entirely (or do absolutely anything else to the document)), just as they
-could alter the resource the hash is meant to validate. Authors who desire
-any sort of security whatsoever SHOULD deliver resources containing
-digests over secure channels.
+could alter the resource the hash is meant to validate. Authors SHOULD
+deliver integrity metadata over secure channels. See also [securing the web][].
+
+[Securing the Web]: https://w3ctag.github.io/web-https/
 </section><!-- /Security::Insecure channels -->
 
 <section>

--- a/specs/subresourceintegrity/spec.markdown
+++ b/specs/subresourceintegrity/spec.markdown
@@ -717,12 +717,13 @@ in general.
 <section>
 ### Insecure channels remain insecure
 
-[Integrity metadata][] delivered over an insecure channel provides no security
-benefit. Attackers can alter the digest in-flight (or remove it entirely (or
-do absolutely anything else to the document)), just as they could alter the
-resource the hash is meant to validate. Authors who desire any sort of
-security whatsoever SHOULD deliver resources containing digests over
-secure channels.
+[Integrity metadata][] delivered over an insecure channel only protects an
+origin against a compromise of the server where an external resources is
+hosted. Network attackers can alter the digest in-flight (or remove it
+entirely (or do absolutely anything else to the document)), just as they
+could alter the resource the hash is meant to validate. Authors who desire
+any sort of security whatsoever SHOULD deliver resources containing
+digests over secure channels.
 </section><!-- /Security::Insecure channels -->
 
 <section>


### PR DESCRIPTION
It's not strictly true that there are no security benefits at all
for including integrity metadata on an insecure page.