### PR TITLE
Move hyperlink auditing ("ping") to the connect-src directive

### DIFF
--- a/specs/content-security-policy/index.src.html
+++ b/specs/content-security-policy/index.src.html
@@ -2286,7 +2286,9 @@ type: method
       <li>Processing the <a
       href="http://dev.w3.org/html5/eventsource/#eventsource"><code>EventSource</code>
       constructor</a>.</li>
-      
+
+      <li>Pinging an endpoint during <a href="http://www.whatwg.org/specs/web-apps/current-work/multipage/semantics.html#hyperlink-auditing">hyperlink auditing</a>.</li>
+
       <li>Sending a beacon via the <a href="https://dvcs.w3.org/hg/webperf/raw-file/tip/specs/Beacon/Overview.html#sec-sendBeacon-method"><code>sendBeacon()</code></a> method [[!BEACON]]</li>
     </ul>
     <section class="informative">
@@ -2469,17 +2471,12 @@ type: method
     <a title="parse a source list">parsing the <code>form-action</code>
     directive's value as a source list</a>.
 
-    Whenever the user agent <a>fetches</a> a URL in the course of one of the
-    following activities, if the URL does not
+    Whenever the user agent <a>fetches</a> a URL in the course of processing
+    an HTML <code><a element>form</a></code> element, if the URL does not
     <a title="match a source list">match</a> the <a>allowed form actions</a> for
     the <a>protected resource</a>, the user agent MUST act as if there was a
     fatal network error and no resource was obtained, <em>and</em> <a>report a
-    violation</a>:
-
-    <ul>
-      <li>Processing an HTML <code><a element>form</a></code> element.</li>
-      <li>Pinging an endpoint during <a href="http://www.whatwg.org/specs/web-apps/current-work/multipage/semantics.html#hyperlink-auditing">hyperlink auditing</a></li>
-    </ul>
+    violation</a>.
 
     Note: <code>form-action</code> does not fall back to the <a>default
     sources</a> when the directive is not defined. That is, a policy that


### PR DESCRIPTION
This change brings the CSP spec in line with the relevant section
of the Fetch standard:

  https://fetch.spec.whatwg.org/#requests

This is implementing the change that was proposed by @dveditz in this thread:

  http://lists.w3.org/Archives/Public/public-webappsec/2014Nov/0259.html