### PR TITLE
`Authorization` is the header likely to be seen, not `WWW-Authenticate`

### DIFF
--- a/specs/subresourceintegrity/spec.markdown
+++ b/specs/subresourceintegrity/spec.markdown
@@ -385,8 +385,8 @@ Certain HTTP headers can also change the way the resource behaves in
 ways which integrity checking cannot account for. If the resource
 contains these headers, it is ineligible for integrity validation:
 
-*   `WWW-Authenticate` hides resources behind a login; such non-public
-    resources are excluded from integrity checks.
+*   `Authorization` or `WWW-Authenticate` hide resources behind a login;
+    such non-public resources are excluded from integrity checks.
 *   `Refresh` can cause IFrame contents to transparently redirect to an
     unintended target, bypassing the integrity check.
 
@@ -400,6 +400,7 @@ The following algorithm details these restrictions:
     <var>resource</var>.
 2.  If <var>resource</var> contains any of the following HTTP headers,
     return `false`:
+    * `Authorization`
     * `WWW-Authenticate`
     * `Refresh`
 3.  If the [mode][fetch-mode] of <var>request</var> is `CORS`,


### PR DESCRIPTION
During a quick review of my SRI patch for Firefox, one of the network
engineers [pointed this out](https://bugzilla.mozilla.org/show_bug.cgi?id=992096#c24):

> Checking for WWW-Authenticate is a non-sense.  It will never pop-up
> here.  Only when credentials are not provided and the channel just
> propagates the 401 response in which case the load fails anyway.
> 
> You should rather check for the "Authorization" request header.

Assuming this is also the case in Chrome, we should change the
spec to make it easier for implementers.

/cc @metromoxie 
