### PR TITLE
Reset links to their original color

### DIFF
--- a/specs/default.css
+++ b/specs/default.css
@@ -81,12 +81,6 @@ body {
 	line-height: 1.5;
 }
 
-a:link, a:visited {
-	border-bottom: 1px solid silver;
-	color: inherit;
-	text-decoration: none;
-}
-
 a.logo:link, a.logo:visited {
 	padding: 0;
 	border-style: none;


### PR DESCRIPTION
Links in spec use default colors, this change was approved by @wseltzer.

It has also been edited on the [spec](http://www.w3.org/TR/2014/WD-powerful-features-20141204/).
