### PR TITLE
Add a note about file URIs (fixes #106)

### DIFF
--- a/specs/subresourceintegrity/spec.markdown
+++ b/specs/subresourceintegrity/spec.markdown
@@ -381,6 +381,15 @@ brute-forcing values via integrity checks, resources are only eligible
 for such checks if they are same-origin, publicly cachable, or are the
 result of explicit access granted to the loading origin via CORS. [[!CORS]]
 
+<div class="note">
+As noted in [RFC6454, section 4](uri-origin), some user agents use
+globally unique identifiers for each file URI. This means that
+resources accessed over a `file` scheme URL are unlikely to be
+eligible for integrity checks.
+
+[uri-origin]: http://tools.ietf.org/html/rfc6454#section-4
+</div>
+
 Certain HTTP headers can also change the way the resource behaves in
 ways which integrity checking cannot account for. If the resource
 contains these headers, it is ineligible for integrity validation:


### PR DESCRIPTION
Web authors may not realize that testing integrity protection is
not going to work if they do so on their local machine using
file:/// URLs.
