### PR TITLE
Stricter hash normalization step

### DIFF
--- a/specs/subresourceintegrity/spec.markdown
+++ b/specs/subresourceintegrity/spec.markdown
@@ -444,8 +444,8 @@ the user agent.
         skip the remaining steps, and proceed to the next token.
     2.  Let <var>algorithm</var> be the <var>alg</var> component of
         <var>token</var>.
-    3.  Strip any dashes from <var>algorithm</var> and transform all ASCII
-        characters to lowercase ASCII.
+    3.  Transform all ASCII characters to lowercase ASCII and remove the dash
+        from the `sha-` prefix in <var>algorithm</var> if there is one.
     4.  If <var>algorithm</var> is a hash function recognized by the user
         agent, add <var>token</var> to <var>result</var>.
 4.  Return <var>result</var>.


### PR DESCRIPTION
The algorithm implemented in 72e081941fdc6ff193e6353745e1b249d8dd0409
was too loose, as pointed out by @mikewest on
https://github.com/w3c/webappsec/pull/125#commitcomment-9150911.