### PR TITLE
Add a requirement to support SHA-384

### DIFF
--- a/specs/subresourceintegrity/spec.markdown
+++ b/specs/subresourceintegrity/spec.markdown
@@ -298,9 +298,9 @@ result of the following command line:
 <section>
 ### Cryptographic hash functions
 
-Conformant user agents MUST support the [SHA-256][sha2] and [SHA-512][sha2]
-cryptographic hash functions for use as part of a resource's
-[integrity metadata][], and MAY support additional hash functions.
+Conformant user agents MUST support the [SHA-256][sha2], [SHA-384][sha2]
+and [SHA-512][sha2] cryptographic hash functions for use as part of a
+resource's [integrity metadata][], and MAY support additional hash functions.
 
 <section>
 #### Agility


### PR DESCRIPTION
We should wait until we come to a decision on this thread: http://lists.w3.org/Archives/Public/public-webappsec/2015Jan/0063.html