### PR TITLE
Separate base64-value and base64url-value

### DIFF
--- a/specs/CSP2/index.html
+++ b/specs/CSP2/index.html
@@ -526,8 +526,8 @@
         
               <li>
           A <a data-link-type="dfn" href="#protected-resource">protected resource</a>’s ability to load Workers is now controlled
-          via <a data-link-type="dfn" href="#child_src"><code>child-src</code></a> rather than
-          <a data-link-type="dfn" href="#script_src"><code>script-src</code></a>.
+          via <a data-link-type="dfn" href="#child-src"><code>child-src</code></a> rather than
+          <a data-link-type="dfn" href="#script-src"><code>script-src</code></a>.
         </li>
               
         
@@ -551,34 +551,34 @@
             <ol>
         
               <li>
-          <a data-link-type="dfn" href="#base_uri"><code>base-uri</code></a> controls the <a data-link-type="dfn" href="#protected-resource" title="protected resource">protected
+          <a data-link-type="dfn" href="#base-uri"><code>base-uri</code></a> controls the <a data-link-type="dfn" href="#protected-resource" title="protected resource">protected
           resource</a>’s ability to specify the <a data-link-spec="HTML5" data-link-type="dfn" href="http://www.w3.org/TR/html5/#document-base-url" title="document base URL">document base
           URL</a>.
         </li>
               
         
               <li>
-          <a data-link-type="dfn" href="#child_src"><code>child-src</code></a> deprecates and replaces
-          <a data-link-type="dfn" href="#frame_src"><code>frame-src</code></a>, controlling the <a data-link-type="dfn" href="#protected-resource" title="protected resource">protected
+          <a data-link-type="dfn" href="#child-src"><code>child-src</code></a> deprecates and replaces
+          <a data-link-type="dfn" href="#frame-src"><code>frame-src</code></a>, controlling the <a data-link-type="dfn" href="#protected-resource" title="protected resource">protected
           resource</a>’s ability to embed frames, and to load Workers.
         </li>
               
         
               <li>
-          <a data-link-type="dfn" href="#form_action"><code>form-action</code></a> controls the <a data-link-type="dfn" href="#protected-resource" title="protected resource">protected
+          <a data-link-type="dfn" href="#form-action"><code>form-action</code></a> controls the <a data-link-type="dfn" href="#protected-resource" title="protected resource">protected
           resource</a>’s ability to submit forms.
         </li>
               
         
               <li>
-          <a data-link-type="dfn" href="#frame_ancestors"><code>frame-ancestors</code></a> controls the <a data-link-type="dfn" href="#protected-resource" title="protected resource">protected
+          <a data-link-type="dfn" href="#frame-ancestors"><code>frame-ancestors</code></a> controls the <a data-link-type="dfn" href="#protected-resource" title="protected resource">protected
           resource</a>’s ability be embedded in other documents. It is meant
           to supplant the <code>X-Frame-Options</code> HTTP request header.
         </li>
               
         
               <li>
-          <a data-link-type="dfn" href="#plugin_types"><code>plugin-types</code></a> controls the <a data-link-type="dfn" href="#protected-resource" title="protected resource">protected
+          <a data-link-type="dfn" href="#plugin-types"><code>plugin-types</code></a> controls the <a data-link-type="dfn" href="#protected-resource" title="protected resource">protected
           resource</a>’s ability to load specific types of plugins.
         </li>
               
@@ -590,7 +590,7 @@
               
         
               <li>
-          <a data-link-type="dfn" href="#reflected_xss"><code>reflected-xss</code></a> controls the user agent’s built-in
+          <a data-link-type="dfn" href="#reflected-xss"><code>reflected-xss</code></a> controls the user agent’s built-in
           heuristics to actively protect against XSS. It is meant to supplant
           the <code>X-XSS-Protection</code> HTTP request header.
         </li>
@@ -623,7 +623,7 @@
     
           <li>
       A number of new fields were added to violation reports (both those POSTED
-      via <a data-link-type="dfn" href="#report_uri"><code>report-uri</code></a>, and those handed to the DOM via
+      via <a data-link-type="dfn" href="#report-uri"><code>report-uri</code></a>, and those handed to the DOM via
       <code class="idl"><a data-link-type="idl" href="#securitypolicyviolationevent">SecurityPolicyViolationEvent</a></code> events. These include
       <code class="idl"><a data-link-for="SecurityPolicyViolationEvent" data-link-type="idl" href="#dom-securitypolicyviolationevent-effectivedirective">effectiveDirective</a></code>,
       <code class="idl"><a data-link-for="SecurityPolicyViolationEvent" data-link-type="idl" href="#dom-securitypolicyviolationevent-statuscode">statusCode</a></code>,
@@ -673,14 +673,14 @@
 
       
             <div class="example">
-        <code><a data-link-type="dfn" href="#script_src">script-src</a> 'self'; <a data-link-type="dfn" href="#object_src">object-src</a> 'none'</code>
+        <code><a data-link-type="dfn" href="#script-src">script-src</a> 'self'; <a data-link-type="dfn" href="#object-src">object-src</a> 'none'</code>
       </div>
             
 
 
             <p>Security policies contain a set of <strong>security policy
-      directives</strong> (<code><a data-link-type="dfn" href="#script_src">script-src</a></code> and
-      <code><a data-link-type="dfn" href="#object_src">object-src</a></code> in the example above), each responsible
+      directives</strong> (<code><a data-link-type="dfn" href="#script-src">script-src</a></code> and
+      <code><a data-link-type="dfn" href="#object-src">object-src</a></code> in the example above), each responsible
       for declaring the restrictions for a particular resource type, or
       manipulating a specific aspect of the policy’s restrictions. The list
       of directives defined by this specification can be found in
@@ -793,13 +793,13 @@
     </dd>
           
     
-          <dt><dfn data-dfn-type="dfn" data-noexport="" id="sha_256">SHA-256<a class="self-link" href="#sha_256"></a></dfn></dt>
+          <dt><dfn data-dfn-type="dfn" data-noexport="" id="sha-256">SHA-256<a class="self-link" href="#sha-256"></a></dfn></dt>
           
     
-          <dt><dfn data-dfn-type="dfn" data-noexport="" id="sha_384">SHA-384<a class="self-link" href="#sha_384"></a></dfn></dt>
+          <dt><dfn data-dfn-type="dfn" data-noexport="" id="sha-384">SHA-384<a class="self-link" href="#sha-384"></a></dfn></dt>
           
     
-          <dt><dfn data-dfn-type="dfn" data-noexport="" id="sha_512">SHA-512<a class="self-link" href="#sha_512"></a></dfn></dt>
+          <dt><dfn data-dfn-type="dfn" data-noexport="" id="sha-512">SHA-512<a class="self-link" href="#sha-512"></a></dfn></dt>
           
     
           <dd>
@@ -906,12 +906,12 @@
           
 
 
-          <p>The <code><dfn data-dfn-type="dfn" data-export="" id="content_security_policy">Content-Security-Policy<a class="self-link" href="#content_security_policy"></a></dfn></code> header field is
+          <p>The <code><dfn data-dfn-type="dfn" data-export="" id="content-security-policy">Content-Security-Policy<a class="self-link" href="#content-security-policy"></a></dfn></code> header field is
     the preferred mechanism for delivering a policy. The grammar is as follows:</p>
           
 
     
-          <pre>"Content-Security-Policy:" 1#<a data-link-type="dfn" href="#policy_token">policy-token</a>
+          <pre>"Content-Security-Policy:" 1#<a data-link-type="dfn" href="#policy-token">policy-token</a>
 </pre>
           
 
@@ -921,7 +921,7 @@
 
     
           <div class="example">
-      <code>Content-Security-Policy: <a data-link-type="dfn" href="#script_src">script-src</a> 'self'</code>
+      <code>Content-Security-Policy: <a data-link-type="dfn" href="#script-src">script-src</a> 'self'</code>
     </div>
           
 
@@ -955,13 +955,13 @@
           
 
 
-          <p>The <code><dfn data-dfn-type="dfn" data-export="" id="content_security_policy_report_only">Content-Security-Policy-Report-Only<a class="self-link" href="#content_security_policy_report_only"></a></dfn></code>
+          <p>The <code><dfn data-dfn-type="dfn" data-export="" id="content-security-policy-report-only">Content-Security-Policy-Report-Only<a class="self-link" href="#content-security-policy-report-only"></a></dfn></code>
     header field lets servers experiment with policies by monitoring (rather
     than enforcing) a policy. The grammar is as follows:</p>
           
 
     
-          <pre>"Content-Security-Policy-Report-Only:" 1#<a data-link-type="dfn" href="#policy_token">policy-token</a>
+          <pre>"Content-Security-Policy-Report-Only:" 1#<a data-link-type="dfn" href="#policy-token">policy-token</a>
 </pre>
           
 
@@ -974,8 +974,8 @@
     
           <div class="example">
       
-            <pre>Content-Security-Policy-Report-Only: <a data-link-type="dfn" href="#script_src">script-src</a> 'self';
-                                     <a data-link-type="dfn" href="#report_uri">report-uri</a> /csp-report-endpoint/
+            <pre>Content-Security-Policy-Report-Only: <a data-link-type="dfn" href="#script-src">script-src</a> 'self';
+                                     <a data-link-type="dfn" href="#report-uri">report-uri</a> /csp-report-endpoint/
 </pre>
             
     
@@ -984,10 +984,10 @@
 
 
           <p>If their site violates this policy the user agent will <a data-link-type="dfn" href="#send-violation-reports" title="send violation reports">send violation
-    reports</a> to the URL specified in the policy’s <a data-link-type="dfn" href="#report_uri">report-uri</a>
+    reports</a> to the URL specified in the policy’s <a data-link-type="dfn" href="#report-uri">report-uri</a>
     directive, but allow the violating resources to load regardless. Once a site
     has confidence that the policy is appropriate, they can start enforcing the
-    policy using the <code><a data-link-type="dfn" href="#content_security_policy">Content-Security-Policy</a></code> header field.</p>
+    policy using the <code><a data-link-type="dfn" href="#content-security-policy">Content-Security-Policy</a></code> header field.</p>
           
 
 
@@ -1011,7 +1011,7 @@
           
 
 
-          <p class="note" role="note">Note: The <code><a data-link-type="dfn" href="#content_security_policy_report_only">Content-Security-Policy-Report-Only</a></code>
+          <p class="note" role="note">Note: The <code><a data-link-type="dfn" href="#content-security-policy-report-only">Content-Security-Policy-Report-Only</a></code>
     header is <em>not</em> supported inside a <code><a data-link-type="element" href="http://www.w3.org/TR/html5/#the-meta-element">meta</a></code>
     element.</p>
           
@@ -1035,7 +1035,7 @@
           
 
     
-          <pre class="example">&lt;meta http-equiv="Content-Security-Policy" content="<a data-link-type="dfn" href="#script_src">script-src</a> 'self'">
+          <pre class="example">&lt;meta http-equiv="Content-Security-Policy" content="<a data-link-type="dfn" href="#script-src">script-src</a> 'self'">
 </pre>
           
 
@@ -1081,8 +1081,8 @@
 
           
                 <li>
-            Remove all occurrences of <code><a data-link-type="dfn" href="#reflected_xss">reflected-xss</a></code>,
-            <code><a data-link-type="dfn" href="#report_uri">report-uri</a></code>, <code><a data-link-type="dfn" href="#frame_ancestors">frame-ancestors</a></code>,
+            Remove all occurrences of <code><a data-link-type="dfn" href="#reflected-xss">reflected-xss</a></code>,
+            <code><a data-link-type="dfn" href="#report-uri">report-uri</a></code>, <code><a data-link-type="dfn" href="#frame-ancestors">frame-ancestors</a></code>,
             and <code><a data-link-type="dfn" href="#sandbox">sandbox</a></code> directives from
             <var>directive-set</var>.
 
@@ -1133,7 +1133,7 @@
           
 
 
-          <p class="note" role="note">Note: The <code><a data-link-type="dfn" href="#content_security_policy_report_only">Content-Security-Policy-Report-Only</a></code>
+          <p class="note" role="note">Note: The <code><a data-link-type="dfn" href="#content-security-policy-report-only">Content-Security-Policy-Report-Only</a></code>
     header is <em>not</em> supported inside a <code><a data-link-type="element" href="http://www.w3.org/TR/html5/#the-meta-element">meta</a></code>
     element.</p>
           
@@ -1153,9 +1153,9 @@
           
 
     
-          <pre>"CSP:" 1#<a data-link-type="dfn" href="#csp_header_value">csp-header-value</a>
+          <pre>"CSP:" 1#<a data-link-type="dfn" href="#csp-header-value">csp-header-value</a>
 
-<dfn data-dfn-type="dfn" data-noexport="" id="csp_header_value">csp-header-value<a class="self-link" href="#csp_header_value"></a></dfn> = *WSP "active" *WSP
+<dfn data-dfn-type="dfn" data-noexport="" id="csp-header-value">csp-header-value<a class="self-link" href="#csp-header-value"></a></dfn> = *WSP "active" *WSP
 </pre>
           
 
@@ -1207,10 +1207,10 @@
           
 
     
-          <pre class="example">Content-Security-Policy: <a data-link-type="dfn" href="#default_src">default-src</a> 'self' http://example.com http://example.net;
-                         <a data-link-type="dfn" href="#connect_src">connect-src</a> 'none';
-Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src</a> http://example.com/;
-                         <a data-link-type="dfn" href="#script_src">script-src</a> http://example.com/
+          <pre class="example">Content-Security-Policy: <a data-link-type="dfn" href="#default-src">default-src</a> 'self' http://example.com http://example.net;
+                         <a data-link-type="dfn" href="#connect-src">connect-src</a> 'none';
+Content-Security-Policy: <a data-link-type="dfn" href="#connect-src">connect-src</a> http://example.com/;
+                         <a data-link-type="dfn" href="#script-src">script-src</a> http://example.com/
 </pre>
           
 
@@ -1219,7 +1219,7 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
     short answer is that the connection is not allowed. Enforcing both
     policies means that a potential connection would have to pass through
     both unscathed. Even though the second policy would allow this
-    connection, the first policy contains <code><a data-link-type="dfn" href="#connect_src">connect-src</a>
+    connection, the first policy contains <code><a data-link-type="dfn" href="#connect-src">connect-src</a>
     'none'</code>, so its enforcement blocks the connection. The impact is
     that adding additional policies to the list of policies to enforce can
     only further restrict the capabilities of the protected resource.</p>
@@ -1229,7 +1229,7 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
           <p>To demonstrate that further, consider a script tag on this page.
     The first policy would lock scripts down to <code>'self'</code>,
     <code>http://example.com</code> and <code>http://example.net</code>
-    via the <code><a data-link-type="dfn" href="#default_src">default-src</a></code> directive. The second, however,
+    via the <code><a data-link-type="dfn" href="#default-src">default-src</a></code> directive. The second, however,
     would only allow script from <code>http://example.com/</code>. Script
     will only load if it meets both policy’s criteria: in this case, the only
     origin that can match is <code>http://example.com</code>, as both
@@ -1470,10 +1470,10 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
           
 
     
-          <pre><dfn data-dfn-type="dfn" data-noexport="" id="policy_token">policy-token<a class="self-link" href="#policy_token"></a></dfn>    = [ <a data-link-type="dfn" href="#directive_token">directive-token</a> *( ";" [ <a data-link-type="dfn" href="#directive_token">directive-token</a> ] ) ]
-<dfn data-dfn-type="dfn" data-noexport="" id="directive_token">directive-token<a class="self-link" href="#directive_token"></a></dfn> = *WSP [ <a data-link-type="dfn" href="#directive_name">directive-name</a> [ WSP <a data-link-type="dfn" href="#directive_value">directive-value</a> ] ]
-<dfn data-dfn-type="dfn" data-noexport="" id="directive_name">directive-name<a class="self-link" href="#directive_name"></a></dfn>  = 1*( ALPHA / DIGIT / "-" )
-<dfn data-dfn-type="dfn" data-noexport="" id="directive_value">directive-value<a class="self-link" href="#directive_value"></a></dfn> = *( WSP / &lt;VCHAR except ";" and ","> )
+          <pre><dfn data-dfn-type="dfn" data-noexport="" id="policy-token">policy-token<a class="self-link" href="#policy-token"></a></dfn>    = [ <a data-link-type="dfn" href="#directive-token">directive-token</a> *( ";" [ <a data-link-type="dfn" href="#directive-token">directive-token</a> ] ) ]
+<dfn data-dfn-type="dfn" data-noexport="" id="directive-token">directive-token<a class="self-link" href="#directive-token"></a></dfn> = *WSP [ <a data-link-type="dfn" href="#directive-name">directive-name</a> [ WSP <a data-link-type="dfn" href="#directive-value">directive-value</a> ] ]
+<dfn data-dfn-type="dfn" data-noexport="" id="directive-name">directive-name<a class="self-link" href="#directive-name"></a></dfn>  = 1*( ALPHA / DIGIT / "-" )
+<dfn data-dfn-type="dfn" data-noexport="" id="directive-value">directive-value<a class="self-link" href="#directive-value"></a></dfn> = *( WSP / &lt;VCHAR except ";" and ","> )
 </pre>
           
 
@@ -1573,40 +1573,41 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
           
 
     
-          <pre><dfn data-dfn-type="dfn" data-noexport="" id="source_list">source-list<a class="self-link" href="#source_list"></a></dfn>       = *WSP [ <a data-link-type="dfn" href="#source_expression">source-expression</a> *( 1*WSP <a data-link-type="dfn" href="#source_expression">source-expression</a> ) *WSP ]
+          <pre><dfn data-dfn-type="dfn" data-noexport="" id="source-list0">source-list<a class="self-link" href="#source-list0"></a></dfn>       = *WSP [ <a data-link-type="dfn" href="#source-expression0">source-expression</a> *( 1*WSP <a data-link-type="dfn" href="#source-expression0">source-expression</a> ) *WSP ]
                   / *WSP "'none'" *WSP
-<dfn data-dfn-type="dfn" data-noexport="" id="source_expression">source-expression<a class="self-link" href="#source_expression"></a></dfn> = <a data-link-type="dfn" href="#scheme_source">scheme-source</a> / <a data-link-type="dfn" href="#host_source">host-source</a> / <a data-link-type="dfn" href="#keyword_source">keyword-source</a> / <a data-link-type="dfn" href="#nonce_source">nonce-source</a> / <a data-link-type="dfn" href="#hash_source">hash-source</a>
-<dfn data-dfn-type="dfn" data-noexport="" id="scheme_source">scheme-source<a class="self-link" href="#scheme_source"></a></dfn>     = <a data-link-type="dfn" href="#scheme_part">scheme-part</a> ":"
-<dfn data-dfn-type="dfn" data-noexport="" id="host_source">host-source<a class="self-link" href="#host_source"></a></dfn>       = [ <a data-link-type="dfn" href="#scheme_part">scheme-part</a> "://" ] <a data-link-type="dfn" href="#host_part">host-part</a> [ <a data-link-type="dfn" href="#port_part">port-part</a> ] [ <a data-link-type="dfn" href="#path_part">path-part</a> ]
-<dfn data-dfn-type="dfn" data-noexport="" id="keyword_source">keyword-source<a class="self-link" href="#keyword_source"></a></dfn>    = "'self'" / "'unsafe-inline'" / "'unsafe-eval'" / "'unsafe-redirect'"
-<dfn data-dfn-type="dfn" data-noexport="" id="base64_value">base64-value<a class="self-link" href="#base64_value"></a></dfn>      = 1*( ALPHA / DIGIT / "+" / "/" / "-" / "_" )*2( "=" )
-<dfn data-dfn-type="dfn" data-noexport="" id="nonce_value">nonce-value<a class="self-link" href="#nonce_value"></a></dfn>       = <a data-link-type="dfn" href="#base64_value">base64-value</a>
-<dfn data-dfn-type="dfn" data-noexport="" id="hash_value">hash-value<a class="self-link" href="#hash_value"></a></dfn>        = <a data-link-type="dfn" href="#base64_value">base64-value</a>
-<dfn data-dfn-type="dfn" data-noexport="" id="nonce_source">nonce-source<a class="self-link" href="#nonce_source"></a></dfn>      = "'nonce-" <a data-link-type="dfn" href="#nonce_value">nonce-value</a> "'"
-<dfn data-dfn-type="dfn" data-noexport="" id="hash_algo">hash-algo<a class="self-link" href="#hash_algo"></a></dfn>         = "sha256" / "sha384" / "sha512"
-<dfn data-dfn-type="dfn" data-noexport="" id="hash_source">hash-source<a class="self-link" href="#hash_source"></a></dfn>       = "'" <a data-link-type="dfn" href="#hash_algo">hash-algo</a> "-" <a data-link-type="dfn" href="#hash_value">hash-value</a> "'"
-<dfn data-dfn-type="dfn" data-noexport="" id="scheme_part">scheme-part<a class="self-link" href="#scheme_part"></a></dfn>       = &lt;scheme production from <a href="https://tools.ietf.org/html/rfc3986#section-3.1">RFC 3986, section 3.1</a>>
-<dfn data-dfn-type="dfn" data-noexport="" id="host_part">host-part<a class="self-link" href="#host_part"></a></dfn>         = <a data-link-type="dfn" href="#wildcard_host">wildcard-host</a> / &lt;IP-literal production from <a href="https://tools.ietf.org/html/rfc3986#section-3.2.2">RFC 3986, section 3.2.2</a>>
+<dfn data-dfn-type="dfn" data-noexport="" id="source-expression0">source-expression<a class="self-link" href="#source-expression0"></a></dfn> = <a data-link-type="dfn" href="#scheme-source">scheme-source</a> / <a data-link-type="dfn" href="#host-source">host-source</a> / <a data-link-type="dfn" href="#keyword-source">keyword-source</a> / <a data-link-type="dfn" href="#nonce-source">nonce-source</a> / <a data-link-type="dfn" href="#hash-source">hash-source</a>
+<dfn data-dfn-type="dfn" data-noexport="" id="scheme-source">scheme-source<a class="self-link" href="#scheme-source"></a></dfn>     = <a data-link-type="dfn" href="#scheme-part">scheme-part</a> ":"
+<dfn data-dfn-type="dfn" data-noexport="" id="host-source">host-source<a class="self-link" href="#host-source"></a></dfn>       = [ <a data-link-type="dfn" href="#scheme-part">scheme-part</a> "://" ] <a data-link-type="dfn" href="#host-part">host-part</a> [ <a data-link-type="dfn" href="#port-part">port-part</a> ] [ <a data-link-type="dfn" href="#path-part">path-part</a> ]
+<dfn data-dfn-type="dfn" data-noexport="" id="keyword-source">keyword-source<a class="self-link" href="#keyword-source"></a></dfn>    = "'self'" / "'unsafe-inline'" / "'unsafe-eval'" / "'unsafe-redirect'"
+<dfn data-dfn-type="dfn" data-noexport="" id="base64-value">base64-value<a class="self-link" href="#base64-value"></a></dfn>      = 1*( ALPHA / DIGIT / "+" / "/" )*2( "=" )
+<dfn data-dfn-type="dfn" data-noexport="" id="base64url-value">base64url-value<a class="self-link" href="#base64url-value"></a></dfn>   = 1*( ALPHA / DIGIT / "-" / "_" )*2( "=" )
+<dfn data-dfn-type="dfn" data-noexport="" id="nonce-value">nonce-value<a class="self-link" href="#nonce-value"></a></dfn>       = <a data-link-type="dfn" href="#base64-value">base64-value</a> / <a data-link-type="dfn" href="#base64url-value">base64url-value</a>
+<dfn data-dfn-type="dfn" data-noexport="" id="hash-value">hash-value<a class="self-link" href="#hash-value"></a></dfn>        = <a data-link-type="dfn" href="#base64-value">base64-value</a> / <a data-link-type="dfn" href="#base64url-value">base64url-value</a>
+<dfn data-dfn-type="dfn" data-noexport="" id="nonce-source">nonce-source<a class="self-link" href="#nonce-source"></a></dfn>      = "'nonce-" <a data-link-type="dfn" href="#nonce-value">nonce-value</a> "'"
+<dfn data-dfn-type="dfn" data-noexport="" id="hash-algo">hash-algo<a class="self-link" href="#hash-algo"></a></dfn>         = "sha256" / "sha384" / "sha512"
+<dfn data-dfn-type="dfn" data-noexport="" id="hash-source">hash-source<a class="self-link" href="#hash-source"></a></dfn>       = "'" <a data-link-type="dfn" href="#hash-algo">hash-algo</a> "-" <a data-link-type="dfn" href="#hash-value">hash-value</a> "'"
+<dfn data-dfn-type="dfn" data-noexport="" id="scheme-part">scheme-part<a class="self-link" href="#scheme-part"></a></dfn>       = &lt;scheme production from <a href="https://tools.ietf.org/html/rfc3986#section-3.1">RFC 3986, section 3.1</a>>
+<dfn data-dfn-type="dfn" data-noexport="" id="host-part">host-part<a class="self-link" href="#host-part"></a></dfn>         = <a data-link-type="dfn" href="#wildcard-host">wildcard-host</a> / &lt;IP-literal production from <a href="https://tools.ietf.org/html/rfc3986#section-3.2.2">RFC 3986, section 3.2.2</a>>
                   &lt;IPv4address production from <a href="https://tools.ietf.org/html/rfc3986#section-3.2.2">RFC 3986, section 3.2.2</a>>
-<dfn data-dfn-type="dfn" data-noexport="" id="wildcard_host">wildcard-host<a class="self-link" href="#wildcard_host"></a></dfn>     = "*" / [ "*." ] 1*<a data-link-type="dfn" href="#host_char">host-char</a> *( "." 1*<a data-link-type="dfn" href="#host_char">host-char</a> )
-<dfn data-dfn-type="dfn" data-noexport="" id="host_char">host-char<a class="self-link" href="#host_char"></a></dfn>         = ALPHA / DIGIT / "-"
-<dfn data-dfn-type="dfn" data-noexport="" id="path_part">path-part<a class="self-link" href="#path_part"></a></dfn>         = &lt;path production from <a href="https://tools.ietf.org/html/rfc3986#section-3.3">RFC 3986, section 3.3</a>>
-<dfn data-dfn-type="dfn" data-noexport="" id="port_part">port-part<a class="self-link" href="#port_part"></a></dfn>         = ":" ( 1*DIGIT / "*" )
+<dfn data-dfn-type="dfn" data-noexport="" id="wildcard-host">wildcard-host<a class="self-link" href="#wildcard-host"></a></dfn>     = "*" / [ "*." ] 1*<a data-link-type="dfn" href="#host-char">host-char</a> *( "." 1*<a data-link-type="dfn" href="#host-char">host-char</a> )
+<dfn data-dfn-type="dfn" data-noexport="" id="host-char">host-char<a class="self-link" href="#host-char"></a></dfn>         = ALPHA / DIGIT / "-"
+<dfn data-dfn-type="dfn" data-noexport="" id="path-part">path-part<a class="self-link" href="#path-part"></a></dfn>         = &lt;path production from <a href="https://tools.ietf.org/html/rfc3986#section-3.3">RFC 3986, section 3.3</a>>
+<dfn data-dfn-type="dfn" data-noexport="" id="port-part">port-part<a class="self-link" href="#port-part"></a></dfn>         = ":" ( 1*DIGIT / "*" )
 </pre>
           
 
 
-          <p>If the policy contains a <code><a data-link-type="dfn" href="#nonce_source">nonce-source</a></code> expression, the
-    server MUST generate a fresh value for the <code><a data-link-type="dfn" href="#nonce_value">nonce-value</a></code>
+          <p>If the policy contains a <code><a data-link-type="dfn" href="#nonce-source">nonce-source</a></code> expression, the
+    server MUST generate a fresh value for the <code><a data-link-type="dfn" href="#nonce-value">nonce-value</a></code>
     directive at random and independently each time it transmits a policy.
     The generated value SHOULD be at least 128 bits long (before encoding),
     and generated via a cryptographically secure random number generator.
-    This requirement ensures that the <code><a data-link-type="dfn" href="#nonce_value">nonce-value</a></code> is
+    This requirement ensures that the <code><a data-link-type="dfn" href="#nonce-value">nonce-value</a></code> is
     difficult for an attacker to predict.</p>
           
 
 
-          <p>The <code><a data-link-type="dfn" href="#host_char">host-char</a></code> production intentionally contains only
+          <p>The <code><a data-link-type="dfn" href="#host-char">host-char</a></code> production intentionally contains only
     ASCII characters; internationalized domain names cannot be entered
     directly into a policy string, but instead MUST be Punycode-encoded
     <a data-biblio-type="normative" data-link-type="biblio" href="#biblio-rfc3492" title="RFC3492">[RFC3492]</a>. For example, the domain <code>üüüüüü.de</code> would be
@@ -1653,7 +1654,7 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
               <li>For each token returned by
         <a data-link-spec="HTML5" data-link-type="dfn" href="http://www.w3.org/TR/html5/#split-a-string-on-spaces" title="split a string on spaces">splitting <var>source
         list</var> on spaces</a>, if the token matches the grammar for
-        <code><a data-link-type="dfn" href="#source_expression">source-expression</a></code>, add the token to the <var>set
+        <code><a data-link-type="dfn" href="#source-expression0">source-expression</a></code>, add the token to the <var>set
         of source expressions</var>.</li>
               
 
@@ -1707,7 +1708,7 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
         
               <li>
           If the source expression matches the grammar for
-          <code><a data-link-type="dfn" href="#scheme_source">scheme-source</a></code>:
+          <code><a data-link-type="dfn" href="#scheme-source">scheme-source</a></code>:
 
           
                 <ol>
@@ -1715,7 +1716,7 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
                   <li>
               If <var>url</var>’s <a data-link-type="dfn" href="http://www.w3.org/TR/url/#concept-url-scheme">scheme</a> is an <a data-link-type="dfn" href="http://www.w3.org/TR/html5/#ascii-case-insensitive" title="ASCII case-insensitive match">ASCII case-insensitive
               match</a> for the source expression’s
-              <code><a data-link-type="dfn" href="#scheme_part">scheme-part</a></code>, return <em>does match</em>.
+              <code><a data-link-type="dfn" href="#scheme-part">scheme-part</a></code>, return <em>does match</em>.
             </li>
                   
 
@@ -1733,7 +1734,7 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
         
               <li>
           If the source expression matches the grammar for
-          <code><a data-link-type="dfn" href="#host_source">host-source</a></code>:
+          <code><a data-link-type="dfn" href="#host-source">host-source</a></code>:
 
           
                 <ol>
@@ -1764,7 +1765,7 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
                   
             
                   <li>
-              If the source expression has a <code><a data-link-type="dfn" href="#scheme_part">scheme-part</a></code>
+              If the source expression has a <code><a data-link-type="dfn" href="#scheme-part">scheme-part</a></code>
               that is not a case insensitive match for <var>url-scheme</var>,
               then return <em>does not match</em>.
             </li>
@@ -1804,7 +1805,7 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
             
                   <li>
               If the first character of the source expression’s
-              <code><a data-link-type="dfn" href="#host_part">host-part</a></code> is an U+002A ASTERISK character
+              <code><a data-link-type="dfn" href="#host-part">host-part</a></code> is an U+002A ASTERISK character
               (<code>*</code>) and the remaining characters, including the
               leading U+002E FULL STOP character (<code>.</code>), are not a
               case insensitive match for the rightmost characters of
@@ -1815,10 +1816,10 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
             
                   <li>
               If the first character of the source expression’s
-              <code><a data-link-type="dfn" href="#host_part">host-part</a></code> is <em>not</em> an U+002A ASTERISK
+              <code><a data-link-type="dfn" href="#host-part">host-part</a></code> is <em>not</em> an U+002A ASTERISK
               character (<code>*</code>) and <var>url-host</var> is not a
               case insensitive match for the source expression’s
-              <code><a data-link-type="dfn" href="#host_part">host-part</a></code>, then return <em>does not
+              <code><a data-link-type="dfn" href="#host-part">host-part</a></code>, then return <em>does not
               match</em>.
             </li>
                   
@@ -1842,13 +1843,13 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
                     <ol>
                 
                       <li>
-                  <code><a data-link-type="dfn" href="#port_part">port-part</a></code> does <strong>not</strong>
+                  <code><a data-link-type="dfn" href="#port-part">port-part</a></code> does <strong>not</strong>
                   contain an U+002A ASTERISK character (<code>*</code>)
                 </li>
                       
                 
                       <li>
-                  <code><a data-link-type="dfn" href="#port_part">port-part</a></code> does <strong>not</strong>
+                  <code><a data-link-type="dfn" href="#port-part">port-part</a></code> does <strong>not</strong>
                   represent the same number as <var>url-port</var>
                 </li>
                       
@@ -1862,7 +1863,7 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
             
                   <li>
               If the source expression contains a non-empty
-              <code><a data-link-type="dfn" href="#path_part">path-part</a></code>, and the URL is <em>not</em> the
+              <code><a data-link-type="dfn" href="#path-part">path-part</a></code>, and the URL is <em>not</em> the
               result of a redirect, then:
 
               
@@ -2064,7 +2065,7 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
         explicitly listed. Policy authors should note that the content of
         such URLs is often derived from a response body or execution in a
         Document context, which may be unsafe. Especially for the
-        <code><a data-link-type="dfn" href="#default_src">default-src</a></code> and <code><a data-link-type="dfn" href="#script_src">script-src</a></code>
+        <code><a data-link-type="dfn" href="#default-src">default-src</a></code> and <code><a data-link-type="dfn" href="#script-src">script-src</a></code>
         directives, policy authors should be aware that allowing "data:" URLs
         is equivalent to <code>unsafe-inline</code> and allowing "blob:" or
         "filesystem:" URLs is equivalent to <code>unsafe-eval</code>.</p>
@@ -2150,7 +2151,7 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
         the matching algorithm ignores the path component of a source
         expression if the resource being loaded is the result of a
         redirect. For example, given a page with an active policy of
-        <code><a data-link-type="dfn" href="#img_src">img-src</a> example.com not-example.com/path</code>:</p>
+        <code><a data-link-type="dfn" href="#img-src">img-src</a> example.com not-example.com/path</code>:</p>
               
 
         
@@ -2263,8 +2264,8 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
       <code><a data-link-for="script" data-link-type="element-attr" href="#element-attrdef-script-nonce">nonce</a></code> attribute after
       <a data-link-spec="HTML5" data-link-type="dfn" href="http://www.w3.org/TR/html5/#strip-leading-and-trailing-whitespace" title="strip leading and trailing whitespace">stripping
       leading and trailing whitespace</a> is a case-sensitive match for the
-      <code><a data-link-type="dfn" href="#nonce_value">nonce-value</a></code> component of at least one
-      <code><a data-link-type="dfn" href="#nonce_source">nonce-source</a></code> expression in <var>set of source
+      <code><a data-link-type="dfn" href="#nonce-value">nonce-value</a></code> component of at least one
+      <code><a data-link-type="dfn" href="#nonce-source">nonce-source</a></code> expression in <var>set of source
       expressions</var>.</p>
             
     
@@ -2300,7 +2301,7 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
             <ol>
         
               <li>Let <var>hashes</var> be a list of all
-        <code><a data-link-type="dfn" href="#hash_source">hash-source</a></code> expressions in <var>set of source
+        <code><a data-link-type="dfn" href="#hash-source">hash-source</a></code> expressions in <var>set of source
         expressions</var>.</li>
               
 
@@ -2313,19 +2314,19 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
               
                     <ul>
                 
-                      <li><a data-link-type="dfn" href="#sha_256">SHA-256</a> if the <code><a data-link-type="dfn" href="#hash_algo">hash-algo</a></code>
+                      <li><a data-link-type="dfn" href="#sha-256">SHA-256</a> if the <code><a data-link-type="dfn" href="#hash-algo">hash-algo</a></code>
                 component of <var>hash</var> is an <a data-link-type="dfn" href="http://www.w3.org/TR/html5/#ascii-case-insensitive" title="ASCII case-insensitive match">ASCII case-insensitive
                 match</a> for the string "sha256" or "sha-256"</li>
                       
 
                 
-                      <li><a data-link-type="dfn" href="#sha_384">SHA-384</a> if the <code><a data-link-type="dfn" href="#hash_algo">hash-algo</a></code>
+                      <li><a data-link-type="dfn" href="#sha-384">SHA-384</a> if the <code><a data-link-type="dfn" href="#hash-algo">hash-algo</a></code>
                 component of <var>hash</var> is an <a data-link-type="dfn" href="http://www.w3.org/TR/html5/#ascii-case-insensitive" title="ASCII case-insensitive match">ASCII case-insensitive
                 match</a> for the string "sha384" or "sha-384"</li>
                       
 
                 
-                      <li><a data-link-type="dfn" href="#sha_512">SHA-512</a> if the <code><a data-link-type="dfn" href="#hash_algo">hash-algo</a></code>
+                      <li><a data-link-type="dfn" href="#sha-512">SHA-512</a> if the <code><a data-link-type="dfn" href="#hash-algo">hash-algo</a></code>
                 component of <var>hash</var> is an <a data-link-type="dfn" href="http://www.w3.org/TR/html5/#ascii-case-insensitive" title="ASCII case-insensitive match">ASCII case-insensitive
                 match</a> for the string "sha512" or "sha-512"</li>
                       
@@ -2337,7 +2338,7 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
                   
 
             
-                  <li>Let <var>expected</var> be the <code><a data-link-type="dfn" href="#hash_value">hash-value</a></code>
+                  <li>Let <var>expected</var> be the <code><a data-link-type="dfn" href="#hash-value">hash-value</a></code>
             component of <var>hash</var>.</li>
                   
 
@@ -2392,7 +2393,7 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
           
 
 
-          <p>The <code><a data-link-type="dfn" href="#plugin_types">plugin-types</a></code> directive uses a value consisting
+          <p>The <code><a data-link-type="dfn" href="#plugin-types">plugin-types</a></code> directive uses a value consisting
     of a <dfn data-dfn-type="dfn" data-noexport="" id="media-type-list">media type list<a class="self-link" href="#media-type-list"></a></dfn>.</p>
           
 
@@ -2403,8 +2404,8 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
           
 
     
-          <pre><dfn data-dfn-type="dfn" data-noexport="" id="media_type_list">media-type-list<a class="self-link" href="#media_type_list"></a></dfn>   = <a data-link-type="dfn" href="#media_type">media-type</a> *( 1*WSP <a data-link-type="dfn" href="#media_type">media-type</a> )
-<dfn data-dfn-type="dfn" data-noexport="" id="media_type">media-type<a class="self-link" href="#media_type"></a></dfn>        = &lt;type from RFC 2045> "/" &lt;subtype from RFC 2045>
+          <pre><dfn data-dfn-type="dfn" data-noexport="" id="media-type-list0">media-type-list<a class="self-link" href="#media-type-list0"></a></dfn>   = <a data-link-type="dfn" href="#media-type0">media-type</a> *( 1*WSP <a data-link-type="dfn" href="#media-type0">media-type</a> )
+<dfn data-dfn-type="dfn" data-noexport="" id="media-type0">media-type<a class="self-link" href="#media-type0"></a></dfn>        = &lt;type from RFC 2045> "/" &lt;subtype from RFC 2045>
 </pre>
           
 
@@ -2429,7 +2430,7 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
               <li>For each token returned by
         <a data-link-spec="HTML5" data-link-type="dfn" href="http://www.w3.org/TR/html5/#split-a-string-on-spaces" title="split a string on spaces">splitting
         <var>media type list</var> on spaces</a>, if the token matches the
-        grammar for <code><a data-link-type="dfn" href="#media_type">media-type</a></code>, add the token to the
+        grammar for <code><a data-link-type="dfn" href="#media-type0">media-type</a></code>, add the token to the
         <var>set of media types</var>. Otherwise ignore the token.</li>
               
 
@@ -2536,9 +2537,9 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
           
                 <dd>The name of the policy directive that was violated. This will
           contain the <a data-link-type="dfn" href="#security-policy-directive">directive</a> whose enforcement triggered the
-          violation (e.g. "<code><a data-link-type="dfn" href="#script_src">script-src</a></code>") even if that
+          violation (e.g. "<code><a data-link-type="dfn" href="#script-src">script-src</a></code>") even if that
           directive does not explicitly appear in the policy, but is
-          implicitly activated via the <code><a data-link-type="dfn" href="#default_src">default-src</a></code>
+          implicitly activated via the <code><a data-link-type="dfn" href="#default-src">default-src</a></code>
           directive.</dd>
                 
 
@@ -2572,7 +2573,7 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
                 
           
                 <dd>The policy directive that was violated, as it appears in the
-          policy. This will contain the <code><a data-link-type="dfn" href="#default_src">default-src</a></code> directive
+          policy. This will contain the <code><a data-link-type="dfn" href="#default-src">default-src</a></code> directive
           in the case of violations caused by falling back to the
           <a data-link-type="dfn" href="#default-sources">default sources</a> when enforcing
           a directive.</dd>
@@ -2587,13 +2588,13 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
       
             <li>If a specific line or a specific file can be identified as the
       cause of the violation (for example, script execution that violates
-      the <code><a data-link-type="dfn" href="#script_src">script-src</a></code> directive), the user agent MAY add the
+      the <code><a data-link-type="dfn" href="#script-src">script-src</a></code> directive), the user agent MAY add the
       following keys and values to <var>violation</var>:
 
         
               <dl>
           
-                <dt id="violation-report-source-file"><a class="self-link" href="#violation-report-source-file"></a><dfn data-dfn-type="dfn" data-noexport="" id="source_file">source-file<a class="self-link" href="#source_file"></a></dfn></dt>
+                <dt id="violation-report-source-file"><a class="self-link" href="#violation-report-source-file"></a><dfn data-dfn-type="dfn" data-noexport="" id="source-file">source-file<a class="self-link" href="#source-file"></a></dfn></dt>
                 
           
                 <dd>The URL of the resource where the violation occurred,
@@ -2604,7 +2605,7 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
                 <dt id="violation-report-line-number"><a class="self-link" href="#violation-report-line-number"></a>line-number</dt>
                 
           
-                <dd>The line number in <code><a data-link-type="dfn" href="#source_file">source-file</a></code> on which
+                <dd>The line number in <code><a data-link-type="dfn" href="#source-file">source-file</a></code> on which
           the violation occurred.</dd>
                 
 
@@ -2612,7 +2613,7 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
                 <dt id="violation-report-column-number"><a class="self-link" href="#violation-report-column-number"></a>column-number</dt>
                 
           
-                <dd>The column number in <code><a data-link-type="dfn" href="#source_file">source-file</a></code> on which
+                <dd>The column number in <code><a data-link-type="dfn" href="#source-file">source-file</a></code> on which
           the violation occurred.</dd>
                 
         
@@ -2760,8 +2761,8 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
 
 
         <p>A server MAY cause user agents to monitor one policy while enforcing
-  another policy by returning both <code><a data-link-type="dfn" href="#content_security_policy">Content-Security-Policy</a></code>
-  and <code><a data-link-type="dfn" href="#content_security_policy_report_only">Content-Security-Policy-Report-Only</a></code> header fields.
+  another policy by returning both <code><a data-link-type="dfn" href="#content-security-policy">Content-Security-Policy</a></code>
+  and <code><a data-link-type="dfn" href="#content-security-policy-report-only">Content-Security-Policy-Report-Only</a></code> header fields.
   For example, if a server operator may wish to <a data-link-type="dfn" href="#enforce">enforce</a> one policy but
   experiment with a stricter policy, she can monitor the stricter policy while
   enforcing the original policy. Once the server operator is satisfied that
@@ -3156,12 +3157,12 @@ interface <dfn class="idl-code" data-dfn-type="interface" data-export="" data-gl
   
         <ul>
     
-          <li>both the <code><a data-link-type="dfn" href="#script_src">script-src</a></code> and
-    <code><a data-link-type="dfn" href="#object_src">object-src</a></code> directives, or</li>
+          <li>both the <code><a data-link-type="dfn" href="#script-src">script-src</a></code> and
+    <code><a data-link-type="dfn" href="#object-src">object-src</a></code> directives, or</li>
           
 
     
-          <li>include a <code><a data-link-type="dfn" href="#default_src">default-src</a></code> directive, which covers both
+          <li>include a <code><a data-link-type="dfn" href="#default-src">default-src</a></code> directive, which covers both
     scripts and plugins.</li>
           
   
@@ -3188,7 +3189,7 @@ interface <dfn class="idl-code" data-dfn-type="interface" data-export="" data-gl
           
 
 
-          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="base_uri">base-uri<a class="self-link" href="#base_uri"></a></dfn></code> directive restricts the URLs that can
+          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="base-uri">base-uri<a class="self-link" href="#base-uri"></a></dfn></code> directive restricts the URLs that can
     be used to specify the <a data-link-spec="HTML5" data-link-type="dfn" href="http://www.w3.org/TR/html5/#document-base-url">document base URL</a>. The syntax for
     the name and value of the directive are described by the following ABNF
     grammar:</p>
@@ -3196,7 +3197,7 @@ interface <dfn class="idl-code" data-dfn-type="interface" data-export="" data-gl
 
     
           <pre>directive-name    = "base-uri"
-directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
+directive-value   = <a data-link-type="dfn" href="#source-list0">source-list</a>
 </pre>
           
 
@@ -3239,7 +3240,7 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
           
 
 
-          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="child_src">child-src<a class="self-link" href="#child_src"></a></dfn></code> directive governs the creation of
+          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="child-src">child-src<a class="self-link" href="#child-src"></a></dfn></code> directive governs the creation of
     <a data-link-spec="HTML5" data-link-type="dfn" href="http://www.w3.org/TR/html5/#nested-browsing-context">nested browsing contexts</a> as well as Worker execution
     contexts. The syntax for the name and value of the directive are described
     by the following ABNF grammar:</p>
@@ -3247,7 +3248,7 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
 
     
           <pre>directive-name    = "child-src"
-directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
+directive-value   = <a data-link-type="dfn" href="#source-list0">source-list</a>
 </pre>
           
 
@@ -3267,7 +3268,7 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
 
 
             <p>To enforce the <code>child-src</code> directive the user agent MUST
-      enforce the <code><a data-link-type="dfn" href="#frame_src">frame-src</a></code> directive.</p>
+      enforce the <code><a data-link-type="dfn" href="#frame-src">frame-src</a></code> directive.</p>
             
     
           </section>
@@ -3301,14 +3302,14 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
           
 
 
-          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="connect_src">connect-src<a class="self-link" href="#connect_src"></a></dfn></code> directive restricts which URLs the
+          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="connect-src">connect-src<a class="self-link" href="#connect-src"></a></dfn></code> directive restricts which URLs the
     protected resource can load using script interfaces. The syntax for the name
     and value of the directive are described by the following ABNF grammar:</p>
           
 
     
           <pre>directive-name    = "connect-src"
-directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
+directive-value   = <a data-link-type="dfn" href="#source-list0">source-list</a>
 </pre>
           
 
@@ -3382,7 +3383,7 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
             
 
 
-            <pre>Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src</a> example.com</pre>
+            <pre>Content-Security-Policy: <a data-link-type="dfn" href="#connect-src">connect-src</a> example.com</pre>
             
 
 
@@ -3418,14 +3419,14 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
           
 
 
-          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="default_src">default-src<a class="self-link" href="#default_src"></a></dfn></code> directive sets a default
+          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="default-src">default-src<a class="self-link" href="#default-src"></a></dfn></code> directive sets a default
     source list for a number of directives. The syntax for the name and
     value of the directive are described by the following ABNF grammar:</p>
           
 
     
           <pre>directive-name    = "default-src"
-directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
+directive-value   = <a data-link-type="dfn" href="#source-list0">source-list</a>
 </pre>
           
 
@@ -3445,28 +3446,28 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
     
           <ul>
       
-            <li><code><a data-link-type="dfn" href="#child_src">child-src</a></code></li>
+            <li><code><a data-link-type="dfn" href="#child-src">child-src</a></code></li>
             
       
-            <li><code><a data-link-type="dfn" href="#connect_src">connect-src</a></code></li>
+            <li><code><a data-link-type="dfn" href="#connect-src">connect-src</a></code></li>
             
       
-            <li><code><a data-link-type="dfn" href="#font_src">font-src</a></code></li>
+            <li><code><a data-link-type="dfn" href="#font-src">font-src</a></code></li>
             
       
-            <li><code><a data-link-type="dfn" href="#img_src">img-src</a></code></li>
+            <li><code><a data-link-type="dfn" href="#img-src">img-src</a></code></li>
             
       
-            <li><code><a data-link-type="dfn" href="#media_src">media-src</a></code></li>
+            <li><code><a data-link-type="dfn" href="#media-src">media-src</a></code></li>
             
       
-            <li><code><a data-link-type="dfn" href="#object_src">object-src</a></code></li>
+            <li><code><a data-link-type="dfn" href="#object-src">object-src</a></code></li>
             
       
-            <li><code><a data-link-type="dfn" href="#script_src">script-src</a></code></li>
+            <li><code><a data-link-type="dfn" href="#script-src">script-src</a></code></li>
             
       
-            <li><code><a data-link-type="dfn" href="#style_src">style-src</a></code></li>
+            <li><code><a data-link-type="dfn" href="#style-src">style-src</a></code></li>
             
     
           </ul>
@@ -3495,7 +3496,7 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
             
 
 
-            <pre>Content-Security-Policy: <a data-link-type="dfn" href="#default_src">default-src</a> 'self'</pre>
+            <pre>Content-Security-Policy: <a data-link-type="dfn" href="#default-src">default-src</a> 'self'</pre>
             
 
 
@@ -3507,14 +3508,14 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
             
 
 
-            <pre>Content-Security-Policy: <a data-link-type="dfn" href="#default_src">default-src</a> 'self'; <a data-link-type="dfn" href="#script_src">script-src</a> example.com</pre>
+            <pre>Content-Security-Policy: <a data-link-type="dfn" href="#default-src">default-src</a> 'self'; <a data-link-type="dfn" href="#script-src">script-src</a> example.com</pre>
             
 
 
             <p>Under this new policy, fonts, frames, and etc. continue to be load
       from the same origin, but scripts will <em>only</em> load from
       <code>example.com</code>. There’s no inheritance; the
-      <code><a data-link-type="dfn" href="#script_src">script-src</a></code> directive sets the allowed sources of
+      <code><a data-link-type="dfn" href="#script-src">script-src</a></code> directive sets the allowed sources of
       script, and the default list is not used for that resource type.</p>
             
 
@@ -3524,7 +3525,7 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
       <code>'none'</code>, and to build up a policy from there that contains
       only those resource types which are actually in use for the page you’d
       like to protect. If you don’t use webfonts, for instance, there’s no
-      reason to specify a source list for <code><a data-link-type="dfn" href="#font_src">font-src</a></code>;
+      reason to specify a source list for <code><a data-link-type="dfn" href="#font-src">font-src</a></code>;
       specifying only those resource types a page uses ensures that the
       possible attack surface for that page remains as small as possible.</p>
             
@@ -3542,14 +3543,14 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
           
 
 
-          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="font_src">font-src<a class="self-link" href="#font_src"></a></dfn></code> directive restricts from where the
+          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="font-src">font-src<a class="self-link" href="#font-src"></a></dfn></code> directive restricts from where the
     protected resource can load fonts. The syntax for the name and value
     of the directive are described by the following ABNF grammar:</p>
           
 
     
           <pre>directive-name    = "font-src"
-directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
+directive-value   = <a data-link-type="dfn" href="#source-list0">source-list</a>
 </pre>
           
 
@@ -3589,14 +3590,14 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
           
 
 
-          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="form_action">form-action<a class="self-link" href="#form_action"></a></dfn></code> restricts which URLs can be used as
+          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="form-action">form-action<a class="self-link" href="#form-action"></a></dfn></code> restricts which URLs can be used as
     the action of HTML <code><a data-link-type="element" href="https://html.spec.whatwg.org/#the-form-element">form</a></code> elements. The syntax for the name and
     value of the directive are described by the following ABNF grammar:</p>
           
 
     
           <pre>directive-name    = "form-action"
-directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
+directive-value   = <a data-link-type="dfn" href="#source-list0">source-list</a>
 </pre>
           
 
@@ -3629,7 +3630,7 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
 
           <p class="note" role="note">Note: <code>form-action</code> does not fall back to the <a data-link-type="dfn" href="#default-sources" title="default sources">default
     sources</a> when the directive is not defined. That is, a policy that
-    defines <code><a data-link-type="dfn" href="#default_src">default-src</a> 'none'</code> but not
+    defines <code><a data-link-type="dfn" href="#default-src">default-src</a> 'none'</code> but not
     <code>form-action</code> will still allow form submissions to any
     target.</p>
           
@@ -3644,7 +3645,7 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
           
 
 
-          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="frame_ancestors">frame-ancestors<a class="self-link" href="#frame_ancestors"></a></dfn></code> directive indicates whether the
+          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="frame-ancestors">frame-ancestors<a class="self-link" href="#frame-ancestors"></a></dfn></code> directive indicates whether the
     user agent should allow embedding the resource using a
     <code><a data-link-type="element" href="http://www.w3.org/TR/html5/#frame">frame</a></code>, <code><a data-link-type="element" href="http://www.w3.org/TR/html5/#the-iframe-element">iframe</a></code>,
     <code><a data-link-type="element" href="http://www.w3.org/TR/html5/#the-object-element">object</a></code>, <code><a data-link-type="element" href="http://www.w3.org/TR/html5/#the-embed-element">embed</a></code> or
@@ -3660,11 +3661,11 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
           
 
     
-          <pre><dfn data-dfn-type="dfn" data-noexport="" id="ancestor_source_list">ancestor-source-list<a class="self-link" href="#ancestor_source_list"></a></dfn> = [ <a data-link-type="dfn" href="#ancestor_source">ancestor-source</a> *( 1*WSP <a data-link-type="dfn" href="#ancestor_source">ancestor-source</a> ) ] / "'none'"
-<dfn data-dfn-type="dfn" data-noexport="" id="ancestor_source">ancestor-source<a class="self-link" href="#ancestor_source"></a></dfn>      = <a data-link-type="dfn" href="#scheme_source">scheme-source</a> / <a data-link-type="dfn" href="#host_source">host-source</a>
+          <pre><dfn data-dfn-type="dfn" data-noexport="" id="ancestor-source-list">ancestor-source-list<a class="self-link" href="#ancestor-source-list"></a></dfn> = [ <a data-link-type="dfn" href="#ancestor-source">ancestor-source</a> *( 1*WSP <a data-link-type="dfn" href="#ancestor-source">ancestor-source</a> ) ] / "'none'"
+<dfn data-dfn-type="dfn" data-noexport="" id="ancestor-source">ancestor-source<a class="self-link" href="#ancestor-source"></a></dfn>      = <a data-link-type="dfn" href="#scheme-source">scheme-source</a> / <a data-link-type="dfn" href="#host-source">host-source</a>
 
 directive-name  = "frame-ancestors"
-directive-value = <a data-link-type="dfn" href="#ancestor_source_list">ancestor-source-list</a>
+directive-value = <a data-link-type="dfn" href="#ancestor-source-list">ancestor-source-list</a>
 </pre>
           
 
@@ -3782,9 +3783,9 @@ directive-value = <a data-link-type="dfn" href="#ancestor_source_list">ancestor-
           
 
 
-          <p class="note" role="note">Note: <code><a data-link-type="dfn" href="#frame_ancestors">frame-ancestors</a></code> does not fall back to the
+          <p class="note" role="note">Note: <code><a data-link-type="dfn" href="#frame-ancestors">frame-ancestors</a></code> does not fall back to the
     <a data-link-type="dfn" href="#default-sources">default sources</a> when the directive is not defined. That is, a policy
-    that defines <code><a data-link-type="dfn" href="#default_src">default-src</a> 'none'</code> but not
+    that defines <code><a data-link-type="dfn" href="#default-src">default-src</a> 'none'</code> but not
     <code>frame-ancestors</code> will still allow the resource to be framed from
     anywhere.</p>
           
@@ -3862,7 +3863,7 @@ directive-value = <a data-link-type="dfn" href="#ancestor_source_list">ancestor-
             
 
       
-            <pre>Content-Security-Policy: <a data-link-type="dfn" href="#frame_ancestors">frame-ancestors</a> https://alice https://bob
+            <pre>Content-Security-Policy: <a data-link-type="dfn" href="#frame-ancestors">frame-ancestors</a> https://alice https://bob
 </pre>
             
 
@@ -3888,7 +3889,7 @@ directive-value = <a data-link-type="dfn" href="#ancestor_source_list">ancestor-
           
 
 
-          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="frame_src">frame-src<a class="self-link" href="#frame_src"></a></dfn></code> directive is <em>deprecated</em>.
+          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="frame-src">frame-src<a class="self-link" href="#frame-src"></a></dfn></code> directive is <em>deprecated</em>.
     Authors who wish to govern nested browsing contexts SHOULD use the
     <code>child-src</code> directive instead.</p>
           
@@ -3902,7 +3903,7 @@ directive-value = <a data-link-type="dfn" href="#ancestor_source_list">ancestor-
 
     
           <pre>directive-name    = "frame-src"
-directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
+directive-value   = <a data-link-type="dfn" href="#source-list0">source-list</a>
 </pre>
           
 
@@ -3947,14 +3948,14 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
           
 
 
-          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="img_src">img-src<a class="self-link" href="#img_src"></a></dfn></code> directive restricts from where the
+          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="img-src">img-src<a class="self-link" href="#img-src"></a></dfn></code> directive restricts from where the
     protected resource can load images. The syntax for the name and value
     of the directive are described by the following ABNF grammar:</p>
           
 
     
           <pre>directive-name    = "img-src"
-directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
+directive-value   = <a data-link-type="dfn" href="#source-list0">source-list</a>
 </pre>
           
 
@@ -4009,7 +4010,7 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
           
 
 
-          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="media_src">media-src<a class="self-link" href="#media_src"></a></dfn></code> directive restricts from where the
+          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="media-src">media-src<a class="self-link" href="#media-src"></a></dfn></code> directive restricts from where the
     protected resource can load video, audio, and associated text tracks.
     The syntax for the name and value of the directive are described by the
     following ABNF grammar:</p>
@@ -4017,7 +4018,7 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
 
     
           <pre>directive-name    = "media-src"
-directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
+directive-value   = <a data-link-type="dfn" href="#source-list0">source-list</a>
 </pre>
           
 
@@ -4060,14 +4061,14 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
           
 
 
-          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="object_src">object-src<a class="self-link" href="#object_src"></a></dfn></code> directive restricts from where
+          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="object-src">object-src<a class="self-link" href="#object-src"></a></dfn></code> directive restricts from where
     the protected resource can load plugins. The syntax for the name and value
     of the directive are described by the following ABNF grammar:</p>
           
 
     
           <pre>directive-name    = "object-src"
-directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
+directive-value   = <a data-link-type="dfn" href="#source-list0">source-list</a>
 </pre>
           
 
@@ -4144,7 +4145,7 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
           
 
 
-          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="plugin_types">plugin-types<a class="self-link" href="#plugin_types"></a></dfn></code> directive restricts the set
+          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="plugin-types">plugin-types<a class="self-link" href="#plugin-types"></a></dfn></code> directive restricts the set
     of plugins that can be invoked by the protected resource by limiting
     the types of resources that can be embedded. The syntax for the name
     and value of the directive are described by the following ABNF
@@ -4247,7 +4248,7 @@ directive-value   = media-type-list
             
 
 
-            <pre>Content-Security-Policy: <a data-link-type="dfn" href="#plugin_types">plugin-types</a> application/pdf</pre>
+            <pre>Content-Security-Policy: <a data-link-type="dfn" href="#plugin-types">plugin-types</a> application/pdf</pre>
             
 
 
@@ -4261,7 +4262,7 @@ directive-value   = media-type-list
             
 
 
-            <pre>Content-Security-Policy: <a data-link-type="dfn" href="#plugin_types">plugin-types</a> application/pdf application/x-shockwave-flash</pre>
+            <pre>Content-Security-Policy: <a data-link-type="dfn" href="#plugin-types">plugin-types</a> application/pdf application/x-shockwave-flash</pre>
             
 
 
@@ -4390,7 +4391,7 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
           
 
 
-          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="reflected_xss">reflected-xss<a class="self-link" href="#reflected_xss"></a></dfn></code> directive instructs a user agent
+          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="reflected-xss">reflected-xss<a class="self-link" href="#reflected-xss"></a></dfn></code> directive instructs a user agent
     to activate or deactivate any heuristics used to filter or block
     reflected cross-site scripting attacks. The syntax for the name and
     value of the directive are described by the following ABNF grammar:</p>
@@ -4490,7 +4491,7 @@ directive-value   = "allow" / "block" / "filter"
           
 
 
-          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="report_uri">report-uri<a class="self-link" href="#report_uri"></a></dfn></code> directive specifies a URL to
+          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="report-uri">report-uri<a class="self-link" href="#report-uri"></a></dfn></code> directive specifies a URL to
     which the user agent sends reports about policy violation. The syntax
     for the name and value of the directive are described by the following
     ABNF grammar:</p>
@@ -4498,8 +4499,8 @@ directive-value   = "allow" / "block" / "filter"
 
     
           <pre>directive-name    = "report-uri"
-directive-value   = <a data-link-type="dfn" href="#uri_reference">uri-reference</a> *( 1*WSP <a data-link-type="dfn" href="#uri_reference">uri-reference</a> )
-<dfn data-dfn-type="dfn" data-noexport="" id="uri_reference">uri-reference<a class="self-link" href="#uri_reference"></a></dfn>     = &lt;URI-reference from RFC 3986>
+directive-value   = <a data-link-type="dfn" href="#uri-reference">uri-reference</a> *( 1*WSP <a data-link-type="dfn" href="#uri-reference">uri-reference</a> )
+<dfn data-dfn-type="dfn" data-noexport="" id="uri-reference">uri-reference<a class="self-link" href="#uri-reference"></a></dfn>     = &lt;URI-reference from RFC 3986>
 </pre>
           
 
@@ -4537,8 +4538,8 @@ directive-value   = <a data-link-type="dfn" href="#uri_reference">uri-reference<
 
     
           <pre>directive-name    = "sandbox"
-directive-value   = "" / sandbox-token *( 1*WSP <a data-link-type="dfn" href="#sandbox_token">sandbox-token</a> )
-<dfn data-dfn-type="dfn" data-noexport="" id="sandbox_token">sandbox-token<a class="self-link" href="#sandbox_token"></a></dfn>     = &lt;token from RFC 7230>
+directive-value   = "" / sandbox-token *( 1*WSP <a data-link-type="dfn" href="#sandbox-token">sandbox-token</a> )
+<dfn data-dfn-type="dfn" data-noexport="" id="sandbox-token">sandbox-token<a class="self-link" href="#sandbox-token"></a></dfn>     = &lt;token from RFC 7230>
 </pre>
           
 
@@ -4661,7 +4662,7 @@ directive-value   = "" / sandbox-token *( 1*WSP <a data-link-type="dfn" href="#s
           
 
 
-          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="script_src">script-src<a class="self-link" href="#script_src"></a></dfn></code> directive restricts which scripts the
+          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="script-src">script-src<a class="self-link" href="#script-src"></a></dfn></code> directive restricts which scripts the
     protected resource can execute. The directive also controls other resources,
     such as XSLT style sheets <a data-biblio-type="normative" data-link-type="biblio" href="#biblio-xslt" title="XSLT">[XSLT]</a>, which can cause the user agent to
     execute script. The syntax for the name and value of the directive are
@@ -4670,7 +4671,7 @@ directive-value   = "" / sandbox-token *( 1*WSP <a data-link-type="dfn" href="#s
 
     
           <pre>directive-name    = "script-src"
-directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
+directive-value   = <a data-link-type="dfn" href="#source-list0">source-list</a>
 </pre>
           
 
@@ -4685,7 +4686,7 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
 
           <p>If <code>'unsafe-inline'</code> is <strong>not</strong> in the
     list of <a data-link-type="dfn" href="#allowed-script-sources">allowed script sources</a>, or if at least one
-    <code><a data-link-type="dfn" href="#nonce_source">nonce-source</a></code> or <code><a data-link-type="dfn" href="#hash_source">hash-source</a></code> is
+    <code><a data-link-type="dfn" href="#nonce-source">nonce-source</a></code> or <code><a data-link-type="dfn" href="#hash-source">hash-source</a></code> is
     present in the list of <a data-link-type="dfn" href="#allowed-script-sources">allowed script sources</a>:</p>
           
 
@@ -4803,7 +4804,7 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
             
 
 
-            <p>The <code><a data-link-type="dfn" href="#script_src">script-src</a></code> directive lets developers specify
+            <p>The <code><a data-link-type="dfn" href="#script-src">script-src</a></code> directive lets developers specify
       exactly which script elements on a page were intentionally included
       for execution. Ideally, developers would avoid inline script entirely
       and whitelist scripts by URL. However, in some cases, removing inline
@@ -4818,8 +4819,8 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
             
 
       
-            <pre>Content-Security-Policy: <a data-link-type="dfn" href="#default_src">default-src</a> 'self';
-                         <a data-link-type="dfn" href="#script_src">script-src</a> 'self' https://example.com 'nonce-<em>$RANDOM</em>'
+            <pre>Content-Security-Policy: <a data-link-type="dfn" href="#default-src">default-src</a> 'self';
+                         <a data-link-type="dfn" href="#script-src">script-src</a> 'self' https://example.com 'nonce-<em>$RANDOM</em>'
 </pre>
             
 
@@ -4832,8 +4833,8 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
             
 
       
-            <pre>Content-Security-Policy: <a data-link-type="dfn" href="#default_src">default-src</a> 'self';
-                         <a data-link-type="dfn" href="#script_src">script-src</a> 'self' https://example.com 'nonce-Nc3n83cnSAd3wc3Sasdfn939hc3'
+            <pre>Content-Security-Policy: <a data-link-type="dfn" href="#default-src">default-src</a> 'self';
+                         <a data-link-type="dfn" href="#script-src">script-src</a> 'self' https://example.com 'nonce-Nc3n83cnSAd3wc3Sasdfn939hc3'
 </pre>
             
 
@@ -4897,7 +4898,7 @@ alert("Allowed because nonce is valid.")
             
 
 
-            <p>The <code><a data-link-type="dfn" href="#script_src">script-src</a></code> directive lets developers whitelist a
+            <p>The <code><a data-link-type="dfn" href="#script-src">script-src</a></code> directive lets developers whitelist a
       particular inline script by specifying its hash as an allowed source
       of script.</p>
             
@@ -4909,8 +4910,8 @@ alert("Allowed because nonce is valid.")
             
 
       
-            <pre>Content-Security-Policy: <a data-link-type="dfn" href="#default_src">default-src</a> 'self';
-                         <a data-link-type="dfn" href="#script_src">script-src</a> 'self' https://example.com 'sha256-<var>base64 encoded hash</var>'
+            <pre>Content-Security-Policy: <a data-link-type="dfn" href="#default-src">default-src</a> 'self';
+                         <a data-link-type="dfn" href="#script-src">script-src</a> 'self' https://example.com 'sha256-<var>base64 encoded hash</var>'
 </pre>
             
 
@@ -4939,7 +4940,7 @@ alert("Allowed because nonce is valid.")
             
 
       
-            <pre>Content-Security-Policy: <a data-link-type="dfn" href="#script_src">script-src</a> 'sha256-YWIzOWNiNzJjNDRlYzc4MTgwMDhmZDlkOWI0NTAyMjgyY2MyMWJlMWUyNjc1ODJlYWJhNjU5MGU4NmZmNGU3OAo='
+            <pre>Content-Security-Policy: <a data-link-type="dfn" href="#script-src">script-src</a> 'sha256-YWIzOWNiNzJjNDRlYzc4MTgwMDhmZDlkOWI0NTAyMjgyY2MyMWJlMWUyNjc1ODJlYWJhNjU5MGU4NmZmNGU3OAo='
 </pre>
             
 
@@ -4987,14 +4988,14 @@ alert('Hello, world.');
           
 
 
-          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="style_src">style-src<a class="self-link" href="#style_src"></a></dfn></code> directive restricts which styles the
+          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="style-src">style-src<a class="self-link" href="#style-src"></a></dfn></code> directive restricts which styles the
     user may applies to the protected resource. The syntax for the name and
     value of the directive are described by the following ABNF grammar:</p>
           
 
     
           <pre>directive-name    = "style-src"
-directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
+directive-value   = <a data-link-type="dfn" href="#source-list0">source-list</a>
 </pre>
           
 
@@ -5008,7 +5009,7 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
 
           <p>If <code>'unsafe-inline'</code> is <strong>not</strong> in the
     list of <a data-link-type="dfn" href="#allowed-style-sources">allowed style sources</a>, or if at least one
-    <code><a data-link-type="dfn" href="#nonce_source">nonce-source</a></code> or <code><a data-link-type="dfn" href="#hash_source">hash-source</a></code>
+    <code><a data-link-type="dfn" href="#nonce-source">nonce-source</a></code> or <code><a data-link-type="dfn" href="#hash-source">hash-source</a></code>
     is present in the list of <a data-link-type="dfn" href="#allowed-style-sources">allowed style sources</a>:</p>
           
 
@@ -5104,7 +5105,7 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
 
 
           <p class="note" role="note">Note: The <code>style-src</code> directive does not restrict the
-    use of XSLT. XSLT is restricted by the <code><a data-link-type="dfn" href="#script_src">script-src</a></code>
+    use of XSLT. XSLT is restricted by the <code><a data-link-type="dfn" href="#script-src">script-src</a></code>
     directive because the security consequences of including an untrusted
     XSLT stylesheet are similar to those incurred by including an
     untrusted script.</p>
@@ -5177,7 +5178,7 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
       A server wishes to load resources only from its own origin:
 
 
-            <pre>Content-Security-Policy: <a data-link-type="dfn" href="#default_src">default-src</a> 'self'</pre>
+            <pre>Content-Security-Policy: <a data-link-type="dfn" href="#default-src">default-src</a> 'self'</pre>
             
     
           </div>
@@ -5192,9 +5193,9 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
 
       
             <pre>Content-Security-Policy:
-    <a data-link-type="dfn" href="#default_src">default-src</a> 'self'; img-src *;
-    <a data-link-type="dfn" href="#object_src">object-src</a> media1.example.com media2.example.com *.cdn.example.com;
-    <a data-link-type="dfn" href="#script_src">script-src</a> trustedscripts.example.com
+    <a data-link-type="dfn" href="#default-src">default-src</a> 'self'; img-src *;
+    <a data-link-type="dfn" href="#object-src">object-src</a> media1.example.com media2.example.com *.cdn.example.com;
+    <a data-link-type="dfn" href="#script-src">script-src</a> trustedscripts.example.com
 </pre>
             
     
@@ -5208,7 +5209,7 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
       content requests:
 
 
-            <pre>Content-Security-Policy: <a data-link-type="dfn" href="#default_src">default-src</a> https: 'unsafe-inline' 'unsafe-eval'</pre>
+            <pre>Content-Security-Policy: <a data-link-type="dfn" href="#default-src">default-src</a> https: 'unsafe-inline' 'unsafe-eval'</pre>
             
 
 
@@ -5228,7 +5229,7 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
       elements it intentionally inserted inline:
 
 
-            <pre>Content-Security-Policy: <a data-link-type="dfn" href="#script_src">script-src</a> 'self' 'nonce-<em>$RANDOM</em>';</pre>
+            <pre>Content-Security-Policy: <a data-link-type="dfn" href="#script-src">script-src</a> 'self' 'nonce-<em>$RANDOM</em>';</pre>
             
 
 
@@ -5265,7 +5266,7 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
           
 
 
-          <pre><a data-link-type="dfn" href="#default_src">default-src</a> 'self'; <a data-link-type="dfn" href="#report_uri">report-uri</a> http://example.org/csp-report.cgi</pre>
+          <pre><a data-link-type="dfn" href="#default-src">default-src</a> 'self'; <a data-link-type="dfn" href="#report-uri">report-uri</a> http://example.org/csp-report.cgi</pre>
           
 
 
@@ -5303,7 +5304,7 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
           
 
 
-          <p>The <code><a data-link-type="dfn" href="#style_src">style-src</a></code> directive restricts the locations from
+          <p>The <code><a data-link-type="dfn" href="#style-src">style-src</a></code> directive restricts the locations from
     which the protected resource can load styles. However, if the user agent uses a
     lax CSS parsing algorithm, an attacker might be able to trick the user
     agent into accepting malicious "stylesheets" hosted by an otherwise
@@ -5351,18 +5352,18 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
         <h2 class="heading settled" data-level="10" id="implementation-considerations"><span class="secno">10. </span><span class="content">Implementation Considerations</span><a class="self-link" href="#implementation-considerations"></a></h2>
 
 
-        <p>The <code><a data-link-type="dfn" href="#content_security_policy">Content-Security-Policy</a></code> header is an end-to-end
+        <p>The <code><a data-link-type="dfn" href="#content-security-policy">Content-Security-Policy</a></code> header is an end-to-end
   header. It is processed and enforced at the client and, therefore,
   SHOULD NOT be modified or removed by proxies or other intermediaries not
   in the same administrative domain as the resource.</p>
 
 
         <p>The originating administrative domain for a resource might wish to
-  apply a <code><a data-link-type="dfn" href="#content_security_policy">Content-Security-Policy</a></code> header outside of the
+  apply a <code><a data-link-type="dfn" href="#content-security-policy">Content-Security-Policy</a></code> header outside of the
   immediate context of an application. For example, a large organization
   might have many resources and applications managed by different
   individuals or teams but all subject to a uniform organizational
-  standard. In such situations, a <code><a data-link-type="dfn" href="#content_security_policy">Content-Security-Policy</a></code>
+  standard. In such situations, a <code><a data-link-type="dfn" href="#content-security-policy">Content-Security-Policy</a></code>
   header might be added or combined with an existing one at a network-edge
   security gateway device or web application firewall. To enforce multiple
   policies, the administrator SHOULD combine the policy into a single header.
@@ -5386,11 +5387,11 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
   by upstream resource owners.</p>
 
 
-        <p>Interactions between the <code><a data-link-type="dfn" href="#default_src">default-src</a></code> and other directives
+        <p>Interactions between the <code><a data-link-type="dfn" href="#default-src">default-src</a></code> and other directives
   SHOULD be given special consideration when combining policies. If none
-  of the policies contains a <code><a data-link-type="dfn" href="#default_src">default-src</a></code> directive, adding new
+  of the policies contains a <code><a data-link-type="dfn" href="#default-src">default-src</a></code> directive, adding new
   src directives results in a more restrictive policy. However, if one or
-  more of the input policies contain a <code><a data-link-type="dfn" href="#default_src">default-src</a></code> directive,
+  more of the input policies contain a <code><a data-link-type="dfn" href="#default-src">default-src</a></code> directive,
   adding new src directives might result in a less restrictive policy, for
   example, if the more specific directive contains a more permissive set of
   allowed origins.</p>
@@ -5416,19 +5417,19 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
     the following headers:
 
     
-          <pre>Content-Security-Policy: <a data-link-type="dfn" href="#frame_ancestors">frame-ancestors</a> https://example.com/ 
-Content-Security-Policy: <a data-link-type="dfn" href="#default_src">default-src</a> https:; report-uri https://example.com/
+          <pre>Content-Security-Policy: <a data-link-type="dfn" href="#frame-ancestors">frame-ancestors</a> https://example.com/ 
+Content-Security-Policy: <a data-link-type="dfn" href="#default-src">default-src</a> https:; report-uri https://example.com/
 </pre>
           
 
 
           <p>would send violation reports for <code>http</code> resources, but would not
-    send violation reports for <code><a data-link-type="dfn" href="#frame_ancestors">frame-ancestors</a></code> violations.
+    send violation reports for <code><a data-link-type="dfn" href="#frame-ancestors">frame-ancestors</a></code> violations.
     Note also that combining them via '<code>,</code>' into the single header</p>
           
 
     
-          <pre>Content-Security-Policy: <a data-link-type="dfn" href="#frame_ancestors">frame-ancestors</a> https://example.com/, <a data-link-type="dfn" href="#default_src">default-src</a> https:; report-uri https://example.com/
+          <pre>Content-Security-Policy: <a data-link-type="dfn" href="#frame-ancestors">frame-ancestors</a> https://example.com/, <a data-link-type="dfn" href="#default-src">default-src</a> https:; report-uri https://example.com/
 </pre>
           
 
@@ -5455,7 +5456,7 @@ Content-Security-Policy: <a data-link-type="dfn" href="#default_src">default-src
         <ol>
     
           <li>
-      The <a data-link-type="dfn" href="#frame_ancestors">frame-ancestor</a> directive MUST take effect before a document is
+      The <a data-link-type="dfn" href="#frame-ancestors">frame-ancestor</a> directive MUST take effect before a document is
       loaded into a <a data-link-type="dfn" href="http://www.w3.org/TR/html5/#nested-browsing-context">nested browsing context</a>, and certainly before script
       is potentially executed. One way to approach this constraint is to perform
       the ancestor check defined in <a data-section="" href="#directive-frame-ancestors">§7.7 frame-ancestors</a> while parsing
@@ -5550,7 +5551,7 @@ Content-Security-Policy: style-src 'none'
             <dt>Specification document</dt>
             
       
-            <dd>This specification (See <code><a data-link-type="dfn" href="#content_security_policy">Content-Security-Policy</a></code>
+            <dd>This specification (See <code><a data-link-type="dfn" href="#content-security-policy">Content-Security-Policy</a></code>
       Header Field)</dd>
             
     
@@ -5600,7 +5601,7 @@ Content-Security-Policy: style-src 'none'
             
       
             <dd>This specification (See
-      <code><a data-link-type="dfn" href="#content_security_policy_report_only">Content-Security-Policy-Report-Only</a></code> Header Field)</dd>
+      <code><a data-link-type="dfn" href="#content-security-policy-report-only">Content-Security-Policy-Report-Only</a></code> Header Field)</dd>
             
     
           </dl>
@@ -5670,7 +5671,7 @@ Content-Security-Policy: style-src 'none'
   <a href="https://tools.ietf.org/id/draft-hodges-websec-framework-reqs">draft-hodges-websec-framework-reqs</a>.</p>
 
 
-        <p>A portion of the <code><a data-link-type="dfn" href="#frame_ancestors">frame-ancestors</a></code> directive was
+        <p>A portion of the <code><a data-link-type="dfn" href="#frame-ancestors">frame-ancestors</a></code> directive was
   originally developed as <code>X-Frame-Options</code>. [RFC7034]</p>
 </section>
 
@@ -5823,10 +5824,11 @@ Content-Security-Policy: style-src 'none'
       <li>allowed script sources, <a href="#allowed-script-sources" title="section 7.17">7.17</a></li>
       <li>allowed style sources, <a href="#allowed-style-sources" title="section 7.18">7.18</a></li>
       <li>ALPHA, <a href="#alpha" title="section 2.4">2.4</a></li>
-      <li>ancestor-source, <a href="#ancestor_source" title="section 7.7">7.7</a></li>
-      <li>ancestor-source-list, <a href="#ancestor_source_list" title="section 7.7">7.7</a></li>
-      <li>base64-value, <a href="#base64_value" title="section 4.2">4.2</a></li>
-      <li>base-uri, <a href="#base_uri" title="section 7.1">7.1</a></li>
+      <li>ancestor-source, <a href="#ancestor-source" title="section 7.7">7.7</a></li>
+      <li>ancestor-source-list, <a href="#ancestor-source-list" title="section 7.7">7.7</a></li>
+      <li>base64url-value, <a href="#base64url-value" title="section 4.2">4.2</a></li>
+      <li>base64-value, <a href="#base64-value" title="section 4.2">4.2</a></li>
+      <li>base-uri, <a href="#base-uri" title="section 7.1">7.1</a></li>
       <li>blockedURI
         <ul>
           <li>attribute for SecurityPolicyViolationEvent, <a href="#dom-securitypolicyviolationevent-blockeduri" title="section 6.1">6.1</a></li>
@@ -5835,7 +5837,7 @@ Content-Security-Policy: style-src 'none'
       </li>
       <li>callable, <a href="#callable" title="section 2.3">2.3</a></li>
       <li>callers, <a href="#callers" title="section 2.3">2.3</a></li>
-      <li>child-src, <a href="#child_src" title="section 7.2">7.2</a></li>
+      <li>child-src, <a href="#child-src" title="section 7.2">7.2</a></li>
       <li>columnNumber
         <ul>
           <li>attribute for SecurityPolicyViolationEvent, <a href="#dom-securitypolicyviolationevent-columnnumber" title="section 6.1">6.1</a></li>
@@ -5844,22 +5846,22 @@ Content-Security-Policy: style-src 'none'
       </li>
       <li>conformant server, <a href="#conformant-server" title="section Unnumbered section">Unnumbered section</a></li>
       <li>conformant user agent, <a href="#conformant-user-agent" title="section Unnumbered section">Unnumbered section</a></li>
-      <li>connect-src, <a href="#connect_src" title="section 7.3">7.3</a></li>
-      <li>Content-Security-Policy, <a href="#content_security_policy" title="section 3.1">3.1</a></li>
-      <li>Content-Security-Policy-Report-Only, <a href="#content_security_policy_report_only" title="section 3.2">3.2</a></li>
+      <li>connect-src, <a href="#connect-src" title="section 7.3">7.3</a></li>
+      <li>Content-Security-Policy, <a href="#content-security-policy" title="section 3.1">3.1</a></li>
+      <li>Content-Security-Policy-Report-Only, <a href="#content-security-policy-report-only" title="section 3.2">3.2</a></li>
       <li>Content Security Policy task
           source, <a href="#content-security-policy-task-source" title="section 4.4">4.4</a></li>
       <li>CSP, <a href="#csp" title="section 3.4">3.4</a></li>
-      <li>csp-header-value, <a href="#csp_header_value" title="section 3.4">3.4</a></li>
+      <li>csp-header-value, <a href="#csp-header-value" title="section 3.4">3.4</a></li>
       <li>default sources, <a href="#default-sources" title="section 7.4">7.4</a></li>
-      <li>default-src, <a href="#default_src" title="section 7.4">7.4</a></li>
+      <li>default-src, <a href="#default-src" title="section 7.4">7.4</a></li>
       <li>digest of element’s content, <a href="#digest-of-elements-content" title="section 4.2.5">4.2.5</a></li>
       <li>DIGIT, <a href="#digit" title="section 2.4">2.4</a></li>
       <li>directive, <a href="#security-policy-directive" title="section 2.1">2.1</a></li>
       <li>directive name, <a href="#security-policy-directive-name" title="section 2.1">2.1</a></li>
-      <li>directive-name, <a href="#directive_name" title="section 4.1">4.1</a></li>
-      <li>directive-token, <a href="#directive_token" title="section 4.1">4.1</a></li>
-      <li>directive-value, <a href="#directive_value" title="section 4.1">4.1</a></li>
+      <li>directive-name, <a href="#directive-name" title="section 4.1">4.1</a></li>
+      <li>directive-token, <a href="#directive-token" title="section 4.1">4.1</a></li>
+      <li>directive-value, <a href="#directive-value" title="section 4.1">4.1</a></li>
       <li>directive value, <a href="#security-policy-directive-value" title="section 2.1">2.1</a></li>
       <li>documentURI
         <ul>
@@ -5877,24 +5879,24 @@ Content-Security-Policy: style-src 'none'
       <li>enforce, <a href="#enforce" title="section 5">5</a></li>
       <li>eventInitDict, <a href="#dom-securitypolicyviolationevent-securitypolicyviolationeventtype-eventinitdict-eventinitdict" title="section 6.1">6.1</a></li>
       <li>fire a violation event, <a href="#fire-a-violation-event" title="section 6.3">6.3</a></li>
-      <li>font-src, <a href="#font_src" title="section 7.5">7.5</a></li>
-      <li>form-action, <a href="#form_action" title="section 7.6">7.6</a></li>
-      <li>frame-ancestors, <a href="#frame_ancestors" title="section 7.7">7.7</a></li>
-      <li>frame-src, <a href="#frame_src" title="section 7.8">7.8</a></li>
+      <li>font-src, <a href="#font-src" title="section 7.5">7.5</a></li>
+      <li>form-action, <a href="#form-action" title="section 7.6">7.6</a></li>
+      <li>frame-ancestors, <a href="#frame-ancestors" title="section 7.7">7.7</a></li>
+      <li>frame-src, <a href="#frame-src" title="section 7.8">7.8</a></li>
       <li>generate a violation report object, <a href="#generate-a-violation-report-object" title="section 4.4">4.4</a></li>
       <li>generating a violation report object, <a href="#generate-a-violation-report-object" title="section 4.4">4.4</a></li>
       <li>globally unique identifier, <a href="#globally-unique-identifier" title="section 2.2">2.2</a></li>
-      <li>hash-algo, <a href="#hash_algo" title="section 4.2">4.2</a></li>
-      <li>hash-source, <a href="#hash_source" title="section 4.2">4.2</a></li>
-      <li>hash-value, <a href="#hash_value" title="section 4.2">4.2</a></li>
-      <li>host-char, <a href="#host_char" title="section 4.2">4.2</a></li>
-      <li>host-part, <a href="#host_part" title="section 4.2">4.2</a></li>
-      <li>host-source, <a href="#host_source" title="section 4.2">4.2</a></li>
+      <li>hash-algo, <a href="#hash-algo" title="section 4.2">4.2</a></li>
+      <li>hash-source, <a href="#hash-source" title="section 4.2">4.2</a></li>
+      <li>hash-value, <a href="#hash-value" title="section 4.2">4.2</a></li>
+      <li>host-char, <a href="#host-char" title="section 4.2">4.2</a></li>
+      <li>host-part, <a href="#host-part" title="section 4.2">4.2</a></li>
+      <li>host-source, <a href="#host-source" title="section 4.2">4.2</a></li>
       <li>HTTP 200 response, <a href="#http-200-response" title="section 2.2">2.2</a></li>
-      <li>img-src, <a href="#img_src" title="section 7.9">7.9</a></li>
+      <li>img-src, <a href="#img-src" title="section 7.9">7.9</a></li>
       <li>JSON object, <a href="#json-object" title="section 2.2">2.2</a></li>
       <li>JSON stringification, <a href="#json-stringification" title="section 2.2">2.2</a></li>
-      <li>keyword-source, <a href="#keyword_source" title="section 4.2">4.2</a></li>
+      <li>keyword-source, <a href="#keyword-source" title="section 4.2">4.2</a></li>
       <li>lineNumber
         <ul>
           <li>attribute for SecurityPolicyViolationEvent, <a href="#dom-securitypolicyviolationevent-linenumber" title="section 6.1">6.1</a></li>
@@ -5904,11 +5906,11 @@ Content-Security-Policy: style-src 'none'
       <li>match a media type list, <a href="#match-a-media-type-list" title="section 4.3.2">4.3.2</a></li>
       <li>match a source expression, <a href="#match-a-source-expression" title="section 4.2.2">4.2.2</a></li>
       <li>match a source list, <a href="#match-a-source-list" title="section 4.2.2">4.2.2</a></li>
-      <li>media-src, <a href="#media_src" title="section 7.10">7.10</a></li>
+      <li>media-src, <a href="#media-src" title="section 7.10">7.10</a></li>
       <li>media type, <a href="#media-type" title="section 4.3">4.3</a></li>
-      <li>media-type, <a href="#media_type" title="section 4.3">4.3</a></li>
+      <li>media-type, <a href="#media-type0" title="section 4.3">4.3</a></li>
       <li>media type list, <a href="#media-type-list" title="section 4.3">4.3</a></li>
-      <li>media-type-list, <a href="#media_type_list" title="section 4.3">4.3</a></li>
+      <li>media-type-list, <a href="#media-type-list0" title="section 4.3">4.3</a></li>
       <li>monitor, <a href="#monitor" title="section 5">5</a></li>
       <li>nonce
         <ul>
@@ -5918,9 +5920,9 @@ Content-Security-Policy: style-src 'none'
           <li>element-attr for style, <a href="#element-attrdef-style-nonce" title="section 4.2.3">4.2.3</a></li>
         </ul>
       </li>
-      <li>nonce-source, <a href="#nonce_source" title="section 4.2">4.2</a></li>
-      <li>nonce-value, <a href="#nonce_value" title="section 4.2">4.2</a></li>
-      <li>object-src, <a href="#object_src" title="section 7.11">7.11</a></li>
+      <li>nonce-source, <a href="#nonce-source" title="section 4.2">4.2</a></li>
+      <li>nonce-value, <a href="#nonce-value" title="section 4.2">4.2</a></li>
+      <li>object-src, <a href="#object-src" title="section 7.11">7.11</a></li>
       <li>origin, <a href="#origin" title="section 2.2">2.2</a></li>
       <li>originalPolicy
         <ul>
@@ -5931,11 +5933,11 @@ Content-Security-Policy: style-src 'none'
       <li>parse a media type list, <a href="#parse-a-media-type-list" title="section 4.3.1">4.3.1</a></li>
       <li>parse a source list, <a href="#parse-a-source-list" title="section 4.2.1">4.2.1</a></li>
       <li>parse the policy, <a href="#parse-the-policy" title="section 4.1.1">4.1.1</a></li>
-      <li>path-part, <a href="#path_part" title="section 4.2">4.2</a></li>
-      <li>plugin-types, <a href="#plugin_types" title="section 7.12">7.12</a></li>
+      <li>path-part, <a href="#path-part" title="section 4.2">4.2</a></li>
+      <li>plugin-types, <a href="#plugin-types" title="section 7.12">7.12</a></li>
       <li>policy, <a href="#security-policy" title="section 2.1">2.1</a></li>
-      <li>policy-token, <a href="#policy_token" title="section 4.1">4.1</a></li>
-      <li>port-part, <a href="#port_part" title="section 4.2">4.2</a></li>
+      <li>policy-token, <a href="#policy-token" title="section 4.1">4.1</a></li>
+      <li>port-part, <a href="#port-part" title="section 4.2">4.2</a></li>
       <li>protected resource, <a href="#protected-resource" title="section 2.1">2.1</a></li>
       <li>referrer
         <ul>
@@ -5944,17 +5946,17 @@ Content-Security-Policy: style-src 'none'
           <li>definition of, <a href="#referrer" title="section 7.13">7.13</a></li>
         </ul>
       </li>
-      <li>reflected-xss, <a href="#reflected_xss" title="section 7.14">7.14</a></li>
+      <li>reflected-xss, <a href="#reflected-xss" title="section 7.14">7.14</a></li>
       <li>report a violation, <a href="#report-a-violation" title="section 4.4">4.4</a></li>
-      <li>report-uri, <a href="#report_uri" title="section 7.15">7.15</a></li>
+      <li>report-uri, <a href="#report-uri" title="section 7.15">7.15</a></li>
       <li>representation, <a href="#resource-representation" title="section 2.2">2.2</a></li>
       <li>resource representation, <a href="#resource-representation" title="section 2.2">2.2</a></li>
       <li>runs a worker, <a href="#runs-a-worker" title="section 2.3">2.3</a></li>
       <li>sandbox, <a href="#sandbox" title="section 7.16">7.16</a></li>
-      <li>sandbox-token, <a href="#sandbox_token" title="section 7.16">7.16</a></li>
-      <li>scheme-part, <a href="#scheme_part" title="section 4.2">4.2</a></li>
-      <li>scheme-source, <a href="#scheme_source" title="section 4.2">4.2</a></li>
-      <li>script-src, <a href="#script_src" title="section 7.17">7.17</a></li>
+      <li>sandbox-token, <a href="#sandbox-token" title="section 7.16">7.16</a></li>
+      <li>scheme-part, <a href="#scheme-part" title="section 4.2">4.2</a></li>
+      <li>scheme-source, <a href="#scheme-source" title="section 4.2">4.2</a></li>
+      <li>script-src, <a href="#script-src" title="section 7.17">7.17</a></li>
       <li>security policy, <a href="#security-policy" title="section 2.1">2.1</a></li>
       <li>security policy directive, <a href="#security-policy-directive" title="section 2.1">2.1</a></li>
       <li>security policy directive name, <a href="#security-policy-directive-name" title="section 2.1">2.1</a></li>
@@ -5964,27 +5966,27 @@ Content-Security-Policy: style-src 'none'
       <li>SecurityPolicyViolationEvent(type, eventInitDict), <a href="#dom-securitypolicyviolationevent-securitypolicyviolationeventtype-eventinitdict" title="section 6.1">6.1</a></li>
       <li>send violation reports, <a href="#send-violation-reports" title="section 4.4">4.4</a></li>
       <li>set of report URLs, <a href="#set-of-report-urls" title="section 7.15">7.15</a></li>
-      <li>SHA-256, <a href="#sha_256" title="section 2.2">2.2</a></li>
-      <li>SHA-384, <a href="#sha_384" title="section 2.2">2.2</a></li>
-      <li>SHA-512, <a href="#sha_512" title="section 2.2">2.2</a></li>
-      <li>source-expression, <a href="#source_expression" title="section 4.2">4.2</a></li>
+      <li>SHA-256, <a href="#sha-256" title="section 2.2">2.2</a></li>
+      <li>SHA-384, <a href="#sha-384" title="section 2.2">2.2</a></li>
+      <li>SHA-512, <a href="#sha-512" title="section 2.2">2.2</a></li>
+      <li>source-expression, <a href="#source-expression0" title="section 4.2">4.2</a></li>
       <li>source expression, <a href="#source-expression" title="section 4.2">4.2</a></li>
-      <li>source-file, <a href="#source_file" title="section 4.4">4.4</a></li>
+      <li>source-file, <a href="#source-file" title="section 4.4">4.4</a></li>
       <li>sourceFile
         <ul>
           <li>attribute for SecurityPolicyViolationEvent, <a href="#dom-securitypolicyviolationevent-sourcefile" title="section 6.1">6.1</a></li>
           <li>dict-member for SecurityPolicyViolationEventInit, <a href="#dom-securitypolicyviolationeventinit-sourcefile" title="section 6.2">6.2</a></li>
         </ul>
       </li>
-      <li>source-list, <a href="#source_list" title="section 4.2">4.2</a></li>
+      <li>source-list, <a href="#source-list0" title="section 4.2">4.2</a></li>
       <li>source
     list, <a href="#source-list" title="section 4.2">4.2</a></li>
       <li>statusCode, <a href="#dom-securitypolicyviolationevent-statuscode" title="section 6.1">6.1</a></li>
       <li>stripped for reporting, <a href="#strip-uri-for-reporting" title="section 4.4">4.4</a></li>
       <li>strip uri for reporting, <a href="#strip-uri-for-reporting" title="section 4.4">4.4</a></li>
-      <li>style-src, <a href="#style_src" title="section 7.18">7.18</a></li>
+      <li>style-src, <a href="#style-src" title="section 7.18">7.18</a></li>
       <li>type, <a href="#dom-securitypolicyviolationevent-securitypolicyviolationeventtype-eventinitdict-type" title="section 6.1">6.1</a></li>
-      <li>uri-reference, <a href="#uri_reference" title="section 7.15">7.15</a></li>
+      <li>uri-reference, <a href="#uri-reference" title="section 7.15">7.15</a></li>
       <li>URL, <a href="#url" title="section 2.2">2.2</a></li>
       <li>valid hash, <a href="#valid-hash" title="section 4.2.5">4.2.5</a></li>
       <li>valid nonce, <a href="#valid-nonce" title="section 4.2.4">4.2.4</a></li>
@@ -5995,7 +5997,7 @@ Content-Security-Policy: style-src 'none'
           <li>dict-member for SecurityPolicyViolationEventInit, <a href="#dom-securitypolicyviolationeventinit-violateddirective" title="section 6.2">6.2</a></li>
         </ul>
       </li>
-      <li>wildcard-host, <a href="#wildcard_host" title="section 4.2">4.2</a></li>
+      <li>wildcard-host, <a href="#wildcard-host" title="section 4.2">4.2</a></li>
       <li>WSP, <a href="#wsp" title="section 2.4">2.4</a></li></ul>
     <h2 class="no-num heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
     <pre class="idl">partial interface <a class="idl-code" data-global-name="" data-link-type="interface" href="https://html.spec.whatwg.org/#htmlscriptelement">HTMLScriptElement</a> {

--- a/specs/CSP2/index.src.html
+++ b/specs/CSP2/index.src.html
@@ -953,9 +953,10 @@ type: interface
       <dfn>scheme-source</dfn>     = <a>scheme-part</a> ":"
       <dfn>host-source</dfn>       = [ <a>scheme-part</a> "://" ] <a>host-part</a> [ <a>port-part</a> ] [ <a>path-part</a> ]
       <dfn>keyword-source</dfn>    = "'self'" / "'unsafe-inline'" / "'unsafe-eval'" / "'unsafe-redirect'"
-      <dfn>base64-value</dfn>      = 1*( ALPHA / DIGIT / "+" / "/" / "-" / "_" )*2( "=" )
-      <dfn>nonce-value</dfn>       = <a>base64-value</a>
-      <dfn>hash-value</dfn>        = <a>base64-value</a>
+      <dfn>base64-value</dfn>      = 1*( ALPHA / DIGIT / "+" / "/" )*2( "=" )
+      <dfn>base64url-value</dfn>   = 1*( ALPHA / DIGIT / "-" / "_" )*2( "=" )
+      <dfn>nonce-value</dfn>       = <a>base64-value</a> / <a>base64url-value</a>
+      <dfn>hash-value</dfn>        = <a>base64-value</a> / <a>base64url-value</a>
       <dfn>nonce-source</dfn>      = "'nonce-" <a>nonce-value</a> "'"
       <dfn>hash-algo</dfn>         = "sha256" / "sha384" / "sha512"
       <dfn>hash-source</dfn>       = "'" <a>hash-algo</a> "-" <a>hash-value</a> "'"

--- a/specs/content-security-policy/index.html
+++ b/specs/content-security-policy/index.html
@@ -506,7 +506,7 @@
             <ol>
         
               <li>
-          <a data-link-type="dfn" href="#manifest_src"><code>manifest-src</code></a> controls the <a data-link-type="dfn" href="#protected-resource" title="protected resource">protected
+          <a data-link-type="dfn" href="#manifest-src"><code>manifest-src</code></a> controls the <a data-link-type="dfn" href="#protected-resource" title="protected resource">protected
           resource</a>’s ability to load application manifests
           <a data-biblio-type="normative" data-link-type="biblio" href="#biblio-manifest" title="MANIFEST">[MANIFEST]</a>.
         </li>
@@ -559,8 +559,8 @@
         
               <li>
           A <a data-link-type="dfn" href="#protected-resource">protected resource</a>’s ability to load Workers is now controlled
-          via <a data-link-type="dfn" href="#child_src"><code>child-src</code></a> rather than
-          <a data-link-type="dfn" href="#script_src"><code>script-src</code></a>.
+          via <a data-link-type="dfn" href="#child-src"><code>child-src</code></a> rather than
+          <a data-link-type="dfn" href="#script-src"><code>script-src</code></a>.
         </li>
               
         
@@ -584,34 +584,34 @@
             <ol>
         
               <li>
-          <a data-link-type="dfn" href="#base_uri"><code>base-uri</code></a> controls the <a data-link-type="dfn" href="#protected-resource" title="protected resource">protected
+          <a data-link-type="dfn" href="#base-uri"><code>base-uri</code></a> controls the <a data-link-type="dfn" href="#protected-resource" title="protected resource">protected
           resource</a>’s ability to specify the <a data-link-spec="HTML5" data-link-type="dfn" href="http://www.w3.org/TR/html5/#document-base-url" title="document base URL">document base
           URL</a>.
         </li>
               
         
               <li>
-          <a data-link-type="dfn" href="#child_src"><code>child-src</code></a> deprecates and replaces
-          <a data-link-type="dfn" href="#frame_src"><code>frame-src</code></a>, controlling the <a data-link-type="dfn" href="#protected-resource" title="protected resource">protected
+          <a data-link-type="dfn" href="#child-src"><code>child-src</code></a> deprecates and replaces
+          <a data-link-type="dfn" href="#frame-src"><code>frame-src</code></a>, controlling the <a data-link-type="dfn" href="#protected-resource" title="protected resource">protected
           resource</a>’s ability to embed frames, and to load Workers.
         </li>
               
         
               <li>
-          <a data-link-type="dfn" href="#form_action"><code>form-action</code></a> controls the <a data-link-type="dfn" href="#protected-resource" title="protected resource">protected
+          <a data-link-type="dfn" href="#form-action"><code>form-action</code></a> controls the <a data-link-type="dfn" href="#protected-resource" title="protected resource">protected
           resource</a>’s ability to submit forms.
         </li>
               
         
               <li>
-          <a data-link-type="dfn" href="#frame_ancestors"><code>frame-ancestors</code></a> controls the <a data-link-type="dfn" href="#protected-resource" title="protected resource">protected
+          <a data-link-type="dfn" href="#frame-ancestors"><code>frame-ancestors</code></a> controls the <a data-link-type="dfn" href="#protected-resource" title="protected resource">protected
           resource</a>’s ability be embedded in other documents. It is meant
           to supplant the <code>X-Frame-Options</code> HTTP request header.
         </li>
               
         
               <li>
-          <a data-link-type="dfn" href="#plugin_types"><code>plugin-types</code></a> controls the <a data-link-type="dfn" href="#protected-resource" title="protected resource">protected
+          <a data-link-type="dfn" href="#plugin-types"><code>plugin-types</code></a> controls the <a data-link-type="dfn" href="#protected-resource" title="protected resource">protected
           resource</a>’s ability to load specific types of plugins.
         </li>
               
@@ -623,7 +623,7 @@
               
         
               <li>
-          <a data-link-type="dfn" href="#reflected_xss"><code>reflected-xss</code></a> controls the user agent’s built-in
+          <a data-link-type="dfn" href="#reflected-xss"><code>reflected-xss</code></a> controls the user agent’s built-in
           heuristics to actively protect against XSS. It is meant to supplant
           the <code>X-XSS-Protection</code> HTTP request header.
         </li>
@@ -656,7 +656,7 @@
     
           <li>
       A number of new fields were added to violation reports (both those POSTED
-      via <a data-link-type="dfn" href="#report_uri"><code>report-uri</code></a>, and those handed to the DOM via
+      via <a data-link-type="dfn" href="#report-uri"><code>report-uri</code></a>, and those handed to the DOM via
       <code class="idl"><a data-link-type="idl" href="#securitypolicyviolationevent">SecurityPolicyViolationEvent</a></code> events. These include
       <code class="idl"><a data-link-for="SecurityPolicyViolationEvent" data-link-type="idl" href="#dom-securitypolicyviolationevent-effectivedirective">effectiveDirective</a></code>,
       <code class="idl"><a data-link-for="SecurityPolicyViolationEvent" data-link-type="idl" href="#dom-securitypolicyviolationevent-statuscode">statusCode</a></code>,
@@ -706,14 +706,14 @@
 
       
             <div class="example">
-        <code><a data-link-type="dfn" href="#script_src">script-src</a> 'self'; <a data-link-type="dfn" href="#object_src">object-src</a> 'none'</code>
+        <code><a data-link-type="dfn" href="#script-src">script-src</a> 'self'; <a data-link-type="dfn" href="#object-src">object-src</a> 'none'</code>
       </div>
             
 
 
             <p>Security policies contain a set of <strong>security policy
-      directives</strong> (<code><a data-link-type="dfn" href="#script_src">script-src</a></code> and
-      <code><a data-link-type="dfn" href="#object_src">object-src</a></code> in the example above), each responsible
+      directives</strong> (<code><a data-link-type="dfn" href="#script-src">script-src</a></code> and
+      <code><a data-link-type="dfn" href="#object-src">object-src</a></code> in the example above), each responsible
       for declaring the restrictions for a particular resource type, or
       manipulating a specific aspect of the policy’s restrictions. The list
       of directives defined by this specification can be found in
@@ -826,13 +826,13 @@
     </dd>
           
     
-          <dt><dfn data-dfn-type="dfn" data-noexport="" id="sha_256">SHA-256<a class="self-link" href="#sha_256"></a></dfn></dt>
+          <dt><dfn data-dfn-type="dfn" data-noexport="" id="sha-256">SHA-256<a class="self-link" href="#sha-256"></a></dfn></dt>
           
     
-          <dt><dfn data-dfn-type="dfn" data-noexport="" id="sha_384">SHA-384<a class="self-link" href="#sha_384"></a></dfn></dt>
+          <dt><dfn data-dfn-type="dfn" data-noexport="" id="sha-384">SHA-384<a class="self-link" href="#sha-384"></a></dfn></dt>
           
     
-          <dt><dfn data-dfn-type="dfn" data-noexport="" id="sha_512">SHA-512<a class="self-link" href="#sha_512"></a></dfn></dt>
+          <dt><dfn data-dfn-type="dfn" data-noexport="" id="sha-512">SHA-512<a class="self-link" href="#sha-512"></a></dfn></dt>
           
     
           <dd>
@@ -939,12 +939,12 @@
           
 
 
-          <p>The <code><dfn data-dfn-type="dfn" data-export="" id="content_security_policy">Content-Security-Policy<a class="self-link" href="#content_security_policy"></a></dfn></code> header field is
+          <p>The <code><dfn data-dfn-type="dfn" data-export="" id="content-security-policy">Content-Security-Policy<a class="self-link" href="#content-security-policy"></a></dfn></code> header field is
     the preferred mechanism for delivering a policy. The grammar is as follows:</p>
           
 
     
-          <pre>"Content-Security-Policy:" 1#<a data-link-type="dfn" href="#policy_token">policy-token</a>
+          <pre>"Content-Security-Policy:" 1#<a data-link-type="dfn" href="#policy-token">policy-token</a>
 </pre>
           
 
@@ -954,7 +954,7 @@
 
     
           <div class="example">
-      <code>Content-Security-Policy: <a data-link-type="dfn" href="#script_src">script-src</a> 'self'</code>
+      <code>Content-Security-Policy: <a data-link-type="dfn" href="#script-src">script-src</a> 'self'</code>
     </div>
           
 
@@ -988,13 +988,13 @@
           
 
 
-          <p>The <code><dfn data-dfn-type="dfn" data-export="" id="content_security_policy_report_only">Content-Security-Policy-Report-Only<a class="self-link" href="#content_security_policy_report_only"></a></dfn></code>
+          <p>The <code><dfn data-dfn-type="dfn" data-export="" id="content-security-policy-report-only">Content-Security-Policy-Report-Only<a class="self-link" href="#content-security-policy-report-only"></a></dfn></code>
     header field lets servers experiment with policies by monitoring (rather
     than enforcing) a policy. The grammar is as follows:</p>
           
 
     
-          <pre>"Content-Security-Policy-Report-Only:" 1#<a data-link-type="dfn" href="#policy_token">policy-token</a>
+          <pre>"Content-Security-Policy-Report-Only:" 1#<a data-link-type="dfn" href="#policy-token">policy-token</a>
 </pre>
           
 
@@ -1007,8 +1007,8 @@
     
           <div class="example">
       
-            <pre>Content-Security-Policy-Report-Only: <a data-link-type="dfn" href="#script_src">script-src</a> 'self';
-                                     <a data-link-type="dfn" href="#report_uri">report-uri</a> /csp-report-endpoint/
+            <pre>Content-Security-Policy-Report-Only: <a data-link-type="dfn" href="#script-src">script-src</a> 'self';
+                                     <a data-link-type="dfn" href="#report-uri">report-uri</a> /csp-report-endpoint/
 </pre>
             
     
@@ -1017,10 +1017,10 @@
 
 
           <p>If their site violates this policy the user agent will <a data-link-type="dfn" href="#send-violation-reports" title="send violation reports">send violation
-    reports</a> to the URL specified in the policy’s <a data-link-type="dfn" href="#report_uri">report-uri</a>
+    reports</a> to the URL specified in the policy’s <a data-link-type="dfn" href="#report-uri">report-uri</a>
     directive, but allow the violating resources to load regardless. Once a site
     has confidence that the policy is appropriate, they can start enforcing the
-    policy using the <code><a data-link-type="dfn" href="#content_security_policy">Content-Security-Policy</a></code> header field.</p>
+    policy using the <code><a data-link-type="dfn" href="#content-security-policy">Content-Security-Policy</a></code> header field.</p>
           
 
 
@@ -1044,7 +1044,7 @@
           
 
 
-          <p class="note" role="note">Note: The <code><a data-link-type="dfn" href="#content_security_policy_report_only">Content-Security-Policy-Report-Only</a></code>
+          <p class="note" role="note">Note: The <code><a data-link-type="dfn" href="#content-security-policy-report-only">Content-Security-Policy-Report-Only</a></code>
     header is <em>not</em> supported inside a <code><a data-link-type="element" href="http://www.w3.org/TR/html5/#the-meta-element">meta</a></code>
     element.</p>
           
@@ -1068,7 +1068,7 @@
           
 
     
-          <pre class="example">&lt;meta http-equiv="Content-Security-Policy" content="<a data-link-type="dfn" href="#script_src">script-src</a> 'self'">
+          <pre class="example">&lt;meta http-equiv="Content-Security-Policy" content="<a data-link-type="dfn" href="#script-src">script-src</a> 'self'">
 </pre>
           
 
@@ -1114,8 +1114,8 @@
 
           
                 <li>
-            Remove all occurrences of <code><a data-link-type="dfn" href="#reflected_xss">reflected-xss</a></code>,
-            <code><a data-link-type="dfn" href="#report_uri">report-uri</a></code>, <code><a data-link-type="dfn" href="#frame_ancestors">frame-ancestors</a></code>,
+            Remove all occurrences of <code><a data-link-type="dfn" href="#reflected-xss">reflected-xss</a></code>,
+            <code><a data-link-type="dfn" href="#report-uri">report-uri</a></code>, <code><a data-link-type="dfn" href="#frame-ancestors">frame-ancestors</a></code>,
             and <code><a data-link-type="dfn" href="#sandbox">sandbox</a></code> directives from
             <var>directive-set</var>.
 
@@ -1166,7 +1166,7 @@
           
 
 
-          <p class="note" role="note">Note: The <code><a data-link-type="dfn" href="#content_security_policy_report_only">Content-Security-Policy-Report-Only</a></code>
+          <p class="note" role="note">Note: The <code><a data-link-type="dfn" href="#content-security-policy-report-only">Content-Security-Policy-Report-Only</a></code>
     header is <em>not</em> supported inside a <code><a data-link-type="element" href="http://www.w3.org/TR/html5/#the-meta-element">meta</a></code>
     element.</p>
           
@@ -1186,9 +1186,9 @@
           
 
     
-          <pre>"CSP:" 1#<a data-link-type="dfn" href="#csp_header_value">csp-header-value</a>
+          <pre>"CSP:" 1#<a data-link-type="dfn" href="#csp-header-value">csp-header-value</a>
 
-<dfn data-dfn-type="dfn" data-noexport="" id="csp_header_value">csp-header-value<a class="self-link" href="#csp_header_value"></a></dfn> = *WSP "active" *WSP
+<dfn data-dfn-type="dfn" data-noexport="" id="csp-header-value">csp-header-value<a class="self-link" href="#csp-header-value"></a></dfn> = *WSP "active" *WSP
 </pre>
           
 
@@ -1240,10 +1240,10 @@
           
 
     
-          <pre class="example">Content-Security-Policy: <a data-link-type="dfn" href="#default_src">default-src</a> 'self' https://example.com https://example.net;
-                         <a data-link-type="dfn" href="#connect_src">connect-src</a> 'none';
-Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src</a> https://example.com/;
-                         <a data-link-type="dfn" href="#script_src">script-src</a> https://example.com/
+          <pre class="example">Content-Security-Policy: <a data-link-type="dfn" href="#default-src">default-src</a> 'self' https://example.com https://example.net;
+                         <a data-link-type="dfn" href="#connect-src">connect-src</a> 'none';
+Content-Security-Policy: <a data-link-type="dfn" href="#connect-src">connect-src</a> https://example.com/;
+                         <a data-link-type="dfn" href="#script-src">script-src</a> https://example.com/
 </pre>
           
 
@@ -1252,7 +1252,7 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
     short answer is that the connection is not allowed. Enforcing both
     policies means that a potential connection would have to pass through
     both unscathed. Even though the second policy would allow this
-    connection, the first policy contains <code><a data-link-type="dfn" href="#connect_src">connect-src</a>
+    connection, the first policy contains <code><a data-link-type="dfn" href="#connect-src">connect-src</a>
     'none'</code>, so its enforcement blocks the connection. The impact is
     that adding additional policies to the list of policies to enforce can
     only further restrict the capabilities of the protected resource.</p>
@@ -1262,7 +1262,7 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
           <p>To demonstrate that further, consider a script tag on this page.
     The first policy would lock scripts down to <code>'self'</code>,
     <code>https://example.com</code> and <code>https://example.net</code>
-    via the <code><a data-link-type="dfn" href="#default_src">default-src</a></code> directive. The second, however,
+    via the <code><a data-link-type="dfn" href="#default-src">default-src</a></code> directive. The second, however,
     would only allow script from <code>https://example.com/</code>. Script
     will only load if it meets both policy’s criteria: in this case, the only
     origin that can match is <code>https://example.com</code>, as both
@@ -1503,10 +1503,10 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
           
 
     
-          <pre><dfn data-dfn-type="dfn" data-noexport="" id="policy_token">policy-token<a class="self-link" href="#policy_token"></a></dfn>    = [ <a data-link-type="dfn" href="#directive_token">directive-token</a> *( ";" [ <a data-link-type="dfn" href="#directive_token">directive-token</a> ] ) ]
-<dfn data-dfn-type="dfn" data-noexport="" id="directive_token">directive-token<a class="self-link" href="#directive_token"></a></dfn> = *WSP [ <a data-link-type="dfn" href="#directive_name">directive-name</a> [ WSP <a data-link-type="dfn" href="#directive_value">directive-value</a> ] ]
-<dfn data-dfn-type="dfn" data-noexport="" id="directive_name">directive-name<a class="self-link" href="#directive_name"></a></dfn>  = 1*( ALPHA / DIGIT / "-" )
-<dfn data-dfn-type="dfn" data-noexport="" id="directive_value">directive-value<a class="self-link" href="#directive_value"></a></dfn> = *( WSP / &lt;VCHAR except ";" and ","> )
+          <pre><dfn data-dfn-type="dfn" data-noexport="" id="policy-token">policy-token<a class="self-link" href="#policy-token"></a></dfn>    = [ <a data-link-type="dfn" href="#directive-token">directive-token</a> *( ";" [ <a data-link-type="dfn" href="#directive-token">directive-token</a> ] ) ]
+<dfn data-dfn-type="dfn" data-noexport="" id="directive-token">directive-token<a class="self-link" href="#directive-token"></a></dfn> = *WSP [ <a data-link-type="dfn" href="#directive-name">directive-name</a> [ WSP <a data-link-type="dfn" href="#directive-value">directive-value</a> ] ]
+<dfn data-dfn-type="dfn" data-noexport="" id="directive-name">directive-name<a class="self-link" href="#directive-name"></a></dfn>  = 1*( ALPHA / DIGIT / "-" )
+<dfn data-dfn-type="dfn" data-noexport="" id="directive-value">directive-value<a class="self-link" href="#directive-value"></a></dfn> = *( WSP / &lt;VCHAR except ";" and ","> )
 </pre>
           
 
@@ -1606,40 +1606,41 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
           
 
     
-          <pre><dfn data-dfn-type="dfn" data-noexport="" id="source_list">source-list<a class="self-link" href="#source_list"></a></dfn>       = *WSP [ <a data-link-type="dfn" href="#source_expression">source-expression</a> *( 1*WSP <a data-link-type="dfn" href="#source_expression">source-expression</a> ) *WSP ]
+          <pre><dfn data-dfn-type="dfn" data-noexport="" id="source-list0">source-list<a class="self-link" href="#source-list0"></a></dfn>       = *WSP [ <a data-link-type="dfn" href="#source-expression0">source-expression</a> *( 1*WSP <a data-link-type="dfn" href="#source-expression0">source-expression</a> ) *WSP ]
                   / *WSP "'none'" *WSP
-<dfn data-dfn-type="dfn" data-noexport="" id="source_expression">source-expression<a class="self-link" href="#source_expression"></a></dfn> = <a data-link-type="dfn" href="#scheme_source">scheme-source</a> / <a data-link-type="dfn" href="#host_source">host-source</a> / <a data-link-type="dfn" href="#keyword_source">keyword-source</a> / <a data-link-type="dfn" href="#nonce_source">nonce-source</a> / <a data-link-type="dfn" href="#hash_source">hash-source</a>
-<dfn data-dfn-type="dfn" data-noexport="" id="scheme_source">scheme-source<a class="self-link" href="#scheme_source"></a></dfn>     = <a data-link-type="dfn" href="#scheme_part">scheme-part</a> ":"
-<dfn data-dfn-type="dfn" data-noexport="" id="host_source">host-source<a class="self-link" href="#host_source"></a></dfn>       = [ <a data-link-type="dfn" href="#scheme_part">scheme-part</a> "://" ] <a data-link-type="dfn" href="#host_part">host-part</a> [ <a data-link-type="dfn" href="#port_part">port-part</a> ] [ <a data-link-type="dfn" href="#path_part">path-part</a> ]
-<dfn data-dfn-type="dfn" data-noexport="" id="keyword_source">keyword-source<a class="self-link" href="#keyword_source"></a></dfn>    = "'self'" / "'unsafe-inline'" / "'unsafe-eval'" / "'unsafe-redirect'"
-<dfn data-dfn-type="dfn" data-noexport="" id="base64_value">base64-value<a class="self-link" href="#base64_value"></a></dfn>      = 1*( ALPHA / DIGIT / "+" / "/" / "-" / "_" )*2( "=" )
-<dfn data-dfn-type="dfn" data-noexport="" id="nonce_value">nonce-value<a class="self-link" href="#nonce_value"></a></dfn>       = <a data-link-type="dfn" href="#base64_value">base64-value</a>
-<dfn data-dfn-type="dfn" data-noexport="" id="hash_value">hash-value<a class="self-link" href="#hash_value"></a></dfn>        = <a data-link-type="dfn" href="#base64_value">base64-value</a>
-<dfn data-dfn-type="dfn" data-noexport="" id="nonce_source">nonce-source<a class="self-link" href="#nonce_source"></a></dfn>      = "'nonce-" <a data-link-type="dfn" href="#nonce_value">nonce-value</a> "'"
-<dfn data-dfn-type="dfn" data-noexport="" id="hash_algo">hash-algo<a class="self-link" href="#hash_algo"></a></dfn>         = "sha256" / "sha384" / "sha512"
-<dfn data-dfn-type="dfn" data-noexport="" id="hash_source">hash-source<a class="self-link" href="#hash_source"></a></dfn>       = "'" <a data-link-type="dfn" href="#hash_algo">hash-algo</a> "-" <a data-link-type="dfn" href="#hash_value">hash-value</a> "'"
-<dfn data-dfn-type="dfn" data-noexport="" id="scheme_part">scheme-part<a class="self-link" href="#scheme_part"></a></dfn>       = &lt;scheme production from <a href="https://tools.ietf.org/html/rfc3986#section-3.1">RFC 3986, section 3.1</a>>
-<dfn data-dfn-type="dfn" data-noexport="" id="host_part">host-part<a class="self-link" href="#host_part"></a></dfn>         = <a data-link-type="dfn" href="#wildcard_host">wildcard-host</a> / &lt;IP-literal production from <a href="https://tools.ietf.org/html/rfc3986#section-3.2.2">RFC 3986, section 3.2.2</a>>
+<dfn data-dfn-type="dfn" data-noexport="" id="source-expression0">source-expression<a class="self-link" href="#source-expression0"></a></dfn> = <a data-link-type="dfn" href="#scheme-source">scheme-source</a> / <a data-link-type="dfn" href="#host-source">host-source</a> / <a data-link-type="dfn" href="#keyword-source">keyword-source</a> / <a data-link-type="dfn" href="#nonce-source">nonce-source</a> / <a data-link-type="dfn" href="#hash-source">hash-source</a>
+<dfn data-dfn-type="dfn" data-noexport="" id="scheme-source">scheme-source<a class="self-link" href="#scheme-source"></a></dfn>     = <a data-link-type="dfn" href="#scheme-part">scheme-part</a> ":"
+<dfn data-dfn-type="dfn" data-noexport="" id="host-source">host-source<a class="self-link" href="#host-source"></a></dfn>       = [ <a data-link-type="dfn" href="#scheme-part">scheme-part</a> "://" ] <a data-link-type="dfn" href="#host-part">host-part</a> [ <a data-link-type="dfn" href="#port-part">port-part</a> ] [ <a data-link-type="dfn" href="#path-part">path-part</a> ]
+<dfn data-dfn-type="dfn" data-noexport="" id="keyword-source">keyword-source<a class="self-link" href="#keyword-source"></a></dfn>    = "'self'" / "'unsafe-inline'" / "'unsafe-eval'" / "'unsafe-redirect'"
+<dfn data-dfn-type="dfn" data-noexport="" id="base64-value">base64-value<a class="self-link" href="#base64-value"></a></dfn>      = 1*( ALPHA / DIGIT / "+" / "/" )*2( "=" )
+<dfn data-dfn-type="dfn" data-noexport="" id="base64url-value">base64url-value<a class="self-link" href="#base64url-value"></a></dfn>   = 1*( ALPHA / DIGIT / "-" / "_" )*2( "=" )
+<dfn data-dfn-type="dfn" data-noexport="" id="nonce-value">nonce-value<a class="self-link" href="#nonce-value"></a></dfn>       = <a data-link-type="dfn" href="#base64-value">base64-value</a> / <a data-link-type="dfn" href="#base64url-value">base64url-value</a>
+<dfn data-dfn-type="dfn" data-noexport="" id="hash-value">hash-value<a class="self-link" href="#hash-value"></a></dfn>        = <a data-link-type="dfn" href="#base64-value">base64-value</a> / <a data-link-type="dfn" href="#base64url-value">base64url-value</a>
+<dfn data-dfn-type="dfn" data-noexport="" id="nonce-source">nonce-source<a class="self-link" href="#nonce-source"></a></dfn>      = "'nonce-" <a data-link-type="dfn" href="#nonce-value">nonce-value</a> "'"
+<dfn data-dfn-type="dfn" data-noexport="" id="hash-algo">hash-algo<a class="self-link" href="#hash-algo"></a></dfn>         = "sha256" / "sha384" / "sha512"
+<dfn data-dfn-type="dfn" data-noexport="" id="hash-source">hash-source<a class="self-link" href="#hash-source"></a></dfn>       = "'" <a data-link-type="dfn" href="#hash-algo">hash-algo</a> "-" <a data-link-type="dfn" href="#hash-value">hash-value</a> "'"
+<dfn data-dfn-type="dfn" data-noexport="" id="scheme-part">scheme-part<a class="self-link" href="#scheme-part"></a></dfn>       = &lt;scheme production from <a href="https://tools.ietf.org/html/rfc3986#section-3.1">RFC 3986, section 3.1</a>>
+<dfn data-dfn-type="dfn" data-noexport="" id="host-part">host-part<a class="self-link" href="#host-part"></a></dfn>         = <a data-link-type="dfn" href="#wildcard-host">wildcard-host</a> / &lt;IP-literal production from <a href="https://tools.ietf.org/html/rfc3986#section-3.2.2">RFC 3986, section 3.2.2</a>>
                   &lt;IPv4address production from <a href="https://tools.ietf.org/html/rfc3986#section-3.2.2">RFC 3986, section 3.2.2</a>>
-<dfn data-dfn-type="dfn" data-noexport="" id="wildcard_host">wildcard-host<a class="self-link" href="#wildcard_host"></a></dfn>     = "*" / [ "*." ] 1*<a data-link-type="dfn" href="#host_char">host-char</a> *( "." 1*<a data-link-type="dfn" href="#host_char">host-char</a> )
-<dfn data-dfn-type="dfn" data-noexport="" id="host_char">host-char<a class="self-link" href="#host_char"></a></dfn>         = ALPHA / DIGIT / "-"
-<dfn data-dfn-type="dfn" data-noexport="" id="path_part">path-part<a class="self-link" href="#path_part"></a></dfn>         = &lt;path production from <a href="https://tools.ietf.org/html/rfc3986#section-3.3">RFC 3986, section 3.3</a>>
-<dfn data-dfn-type="dfn" data-noexport="" id="port_part">port-part<a class="self-link" href="#port_part"></a></dfn>         = ":" ( 1*DIGIT / "*" )
+<dfn data-dfn-type="dfn" data-noexport="" id="wildcard-host">wildcard-host<a class="self-link" href="#wildcard-host"></a></dfn>     = "*" / [ "*." ] 1*<a data-link-type="dfn" href="#host-char">host-char</a> *( "." 1*<a data-link-type="dfn" href="#host-char">host-char</a> )
+<dfn data-dfn-type="dfn" data-noexport="" id="host-char">host-char<a class="self-link" href="#host-char"></a></dfn>         = ALPHA / DIGIT / "-"
+<dfn data-dfn-type="dfn" data-noexport="" id="path-part">path-part<a class="self-link" href="#path-part"></a></dfn>         = &lt;path production from <a href="https://tools.ietf.org/html/rfc3986#section-3.3">RFC 3986, section 3.3</a>>
+<dfn data-dfn-type="dfn" data-noexport="" id="port-part">port-part<a class="self-link" href="#port-part"></a></dfn>         = ":" ( 1*DIGIT / "*" )
 </pre>
           
 
 
-          <p>If the policy contains a <code><a data-link-type="dfn" href="#nonce_source">nonce-source</a></code> expression, the
-    server MUST generate a fresh value for the <code><a data-link-type="dfn" href="#nonce_value">nonce-value</a></code>
+          <p>If the policy contains a <code><a data-link-type="dfn" href="#nonce-source">nonce-source</a></code> expression, the
+    server MUST generate a fresh value for the <code><a data-link-type="dfn" href="#nonce-value">nonce-value</a></code>
     directive at random and independently each time it transmits a policy.
     The generated value SHOULD be at least 128 bits long (before encoding),
     and generated via a cryptographically secure random number generator.
-    This requirement ensures that the <code><a data-link-type="dfn" href="#nonce_value">nonce-value</a></code> is
+    This requirement ensures that the <code><a data-link-type="dfn" href="#nonce-value">nonce-value</a></code> is
     difficult for an attacker to predict.</p>
           
 
 
-          <p>The <code><a data-link-type="dfn" href="#host_char">host-char</a></code> production intentionally contains only
+          <p>The <code><a data-link-type="dfn" href="#host-char">host-char</a></code> production intentionally contains only
     ASCII characters; internationalized domain names cannot be entered
     directly into a policy string, but instead MUST be Punycode-encoded
     <a data-biblio-type="normative" data-link-type="biblio" href="#biblio-rfc3492" title="RFC3492">[RFC3492]</a>. For example, the domain <code>üüüüüü.de</code> would be
@@ -1686,7 +1687,7 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
               <li>For each token returned by
         <a data-link-spec="HTML5" data-link-type="dfn" href="http://www.w3.org/TR/html5/#split-a-string-on-spaces" title="split a string on spaces">splitting <var>source
         list</var> on spaces</a>, if the token matches the grammar for
-        <code><a data-link-type="dfn" href="#source_expression">source-expression</a></code>, add the token to the <var>set
+        <code><a data-link-type="dfn" href="#source-expression0">source-expression</a></code>, add the token to the <var>set
         of source expressions</var>.</li>
               
 
@@ -1740,7 +1741,7 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
         
               <li>
           If the source expression matches the grammar for
-          <code><a data-link-type="dfn" href="#scheme_source">scheme-source</a></code>:
+          <code><a data-link-type="dfn" href="#scheme-source">scheme-source</a></code>:
 
           
                 <ol>
@@ -1748,7 +1749,7 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
                   <li>
               If <var>url</var>’s <a data-link-type="dfn" href="http://www.w3.org/TR/url/#concept-url-scheme">scheme</a> is an <a data-link-type="dfn" href="http://www.w3.org/TR/html5/#ascii-case-insensitive" title="ASCII case-insensitive match">ASCII case-insensitive
               match</a> for the source expression’s
-              <code><a data-link-type="dfn" href="#scheme_part">scheme-part</a></code>, return <em>does match</em>.
+              <code><a data-link-type="dfn" href="#scheme-part">scheme-part</a></code>, return <em>does match</em>.
             </li>
                   
 
@@ -1766,7 +1767,7 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
         
               <li>
           If the source expression matches the grammar for
-          <code><a data-link-type="dfn" href="#host_source">host-source</a></code>:
+          <code><a data-link-type="dfn" href="#host-source">host-source</a></code>:
 
           
                 <ol>
@@ -1797,7 +1798,7 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
                   
             
                   <li>
-              If the source expression has a <code><a data-link-type="dfn" href="#scheme_part">scheme-part</a></code>
+              If the source expression has a <code><a data-link-type="dfn" href="#scheme-part">scheme-part</a></code>
               that is not a case insensitive match for <var>url-scheme</var>,
               then return <em>does not match</em>.
             </li>
@@ -1837,7 +1838,7 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
             
                   <li>
               If the first character of the source expression’s
-              <code><a data-link-type="dfn" href="#host_part">host-part</a></code> is an U+002A ASTERISK character
+              <code><a data-link-type="dfn" href="#host-part">host-part</a></code> is an U+002A ASTERISK character
               (<code>*</code>) and the remaining characters, including the
               leading U+002E FULL STOP character (<code>.</code>), are not a
               case insensitive match for the rightmost characters of
@@ -1848,10 +1849,10 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
             
                   <li>
               If the first character of the source expression’s
-              <code><a data-link-type="dfn" href="#host_part">host-part</a></code> is <em>not</em> an U+002A ASTERISK
+              <code><a data-link-type="dfn" href="#host-part">host-part</a></code> is <em>not</em> an U+002A ASTERISK
               character (<code>*</code>) and <var>url-host</var> is not a
               case insensitive match for the source expression’s
-              <code><a data-link-type="dfn" href="#host_part">host-part</a></code>, then return <em>does not
+              <code><a data-link-type="dfn" href="#host-part">host-part</a></code>, then return <em>does not
               match</em>.
             </li>
                   
@@ -1875,13 +1876,13 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
                     <ol>
                 
                       <li>
-                  <code><a data-link-type="dfn" href="#port_part">port-part</a></code> does <strong>not</strong>
+                  <code><a data-link-type="dfn" href="#port-part">port-part</a></code> does <strong>not</strong>
                   contain an U+002A ASTERISK character (<code>*</code>)
                 </li>
                       
                 
                       <li>
-                  <code><a data-link-type="dfn" href="#port_part">port-part</a></code> does <strong>not</strong>
+                  <code><a data-link-type="dfn" href="#port-part">port-part</a></code> does <strong>not</strong>
                   represent the same number as <var>url-port</var>
                 </li>
                       
@@ -1895,7 +1896,7 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
             
                   <li>
               If the source expression contains a non-empty
-              <code><a data-link-type="dfn" href="#path_part">path-part</a></code>, and the URL is <em>not</em> the
+              <code><a data-link-type="dfn" href="#path-part">path-part</a></code>, and the URL is <em>not</em> the
               result of a redirect, then:
 
               
@@ -2098,7 +2099,7 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
         explicitly listed. Policy authors should note that the content of
         such URLs is often derived from a response body or execution in a
         Document context, which may be unsafe. Especially for the
-        <code><a data-link-type="dfn" href="#default_src">default-src</a></code> and <code><a data-link-type="dfn" href="#script_src">script-src</a></code>
+        <code><a data-link-type="dfn" href="#default-src">default-src</a></code> and <code><a data-link-type="dfn" href="#script-src">script-src</a></code>
         directives, policy authors should be aware that allowing "data:" URLs
         is equivalent to <code>unsafe-inline</code> and allowing "blob:" or
         "filesystem:" URLs is equivalent to <code>unsafe-eval</code>.</p>
@@ -2184,7 +2185,7 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
         the matching algorithm ignores the path component of a source
         expression if the resource being loaded is the result of a
         redirect. For example, given a page with an active policy of
-        <code><a data-link-type="dfn" href="#img_src">img-src</a> example.com not-example.com/path</code>:</p>
+        <code><a data-link-type="dfn" href="#img-src">img-src</a> example.com not-example.com/path</code>:</p>
               
 
         
@@ -2297,8 +2298,8 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
       <code><a data-link-for="script" data-link-type="element-attr" href="#element-attrdef-script-nonce">nonce</a></code> attribute after
       <a data-link-spec="HTML5" data-link-type="dfn" href="http://www.w3.org/TR/html5/#strip-leading-and-trailing-whitespace" title="strip leading and trailing whitespace">stripping
       leading and trailing whitespace</a> is a case-sensitive match for the
-      <code><a data-link-type="dfn" href="#nonce_value">nonce-value</a></code> component of at least one
-      <code><a data-link-type="dfn" href="#nonce_source">nonce-source</a></code> expression in <var>set of source
+      <code><a data-link-type="dfn" href="#nonce-value">nonce-value</a></code> component of at least one
+      <code><a data-link-type="dfn" href="#nonce-source">nonce-source</a></code> expression in <var>set of source
       expressions</var>.</p>
             
     
@@ -2334,7 +2335,7 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
             <ol>
         
               <li>Let <var>hashes</var> be a list of all
-        <code><a data-link-type="dfn" href="#hash_source">hash-source</a></code> expressions in <var>set of source
+        <code><a data-link-type="dfn" href="#hash-source">hash-source</a></code> expressions in <var>set of source
         expressions</var>.</li>
               
 
@@ -2347,19 +2348,19 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
               
                     <ul>
                 
-                      <li><a data-link-type="dfn" href="#sha_256">SHA-256</a> if the <code><a data-link-type="dfn" href="#hash_algo">hash-algo</a></code>
+                      <li><a data-link-type="dfn" href="#sha-256">SHA-256</a> if the <code><a data-link-type="dfn" href="#hash-algo">hash-algo</a></code>
                 component of <var>hash</var> is an <a data-link-type="dfn" href="http://www.w3.org/TR/html5/#ascii-case-insensitive" title="ASCII case-insensitive match">ASCII case-insensitive
                 match</a> for the string "sha256" or "sha-256"</li>
                       
 
                 
-                      <li><a data-link-type="dfn" href="#sha_384">SHA-384</a> if the <code><a data-link-type="dfn" href="#hash_algo">hash-algo</a></code>
+                      <li><a data-link-type="dfn" href="#sha-384">SHA-384</a> if the <code><a data-link-type="dfn" href="#hash-algo">hash-algo</a></code>
                 component of <var>hash</var> is an <a data-link-type="dfn" href="http://www.w3.org/TR/html5/#ascii-case-insensitive" title="ASCII case-insensitive match">ASCII case-insensitive
                 match</a> for the string "sha384" or "sha-384"</li>
                       
 
                 
-                      <li><a data-link-type="dfn" href="#sha_512">SHA-512</a> if the <code><a data-link-type="dfn" href="#hash_algo">hash-algo</a></code>
+                      <li><a data-link-type="dfn" href="#sha-512">SHA-512</a> if the <code><a data-link-type="dfn" href="#hash-algo">hash-algo</a></code>
                 component of <var>hash</var> is an <a data-link-type="dfn" href="http://www.w3.org/TR/html5/#ascii-case-insensitive" title="ASCII case-insensitive match">ASCII case-insensitive
                 match</a> for the string "sha512" or "sha-512"</li>
                       
@@ -2371,7 +2372,7 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
                   
 
             
-                  <li>Let <var>expected</var> be the <code><a data-link-type="dfn" href="#hash_value">hash-value</a></code>
+                  <li>Let <var>expected</var> be the <code><a data-link-type="dfn" href="#hash-value">hash-value</a></code>
             component of <var>hash</var>.</li>
                   
 
@@ -2426,7 +2427,7 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
           
 
 
-          <p>The <code><a data-link-type="dfn" href="#plugin_types">plugin-types</a></code> directive uses a value consisting
+          <p>The <code><a data-link-type="dfn" href="#plugin-types">plugin-types</a></code> directive uses a value consisting
     of a <dfn data-dfn-type="dfn" data-noexport="" id="media-type-list">media type list<a class="self-link" href="#media-type-list"></a></dfn>.</p>
           
 
@@ -2437,8 +2438,8 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
           
 
     
-          <pre><dfn data-dfn-type="dfn" data-noexport="" id="media_type_list">media-type-list<a class="self-link" href="#media_type_list"></a></dfn>   = <a data-link-type="dfn" href="#media_type">media-type</a> *( 1*WSP <a data-link-type="dfn" href="#media_type">media-type</a> )
-<dfn data-dfn-type="dfn" data-noexport="" id="media_type">media-type<a class="self-link" href="#media_type"></a></dfn>        = &lt;type from RFC 2045> "/" &lt;subtype from RFC 2045>
+          <pre><dfn data-dfn-type="dfn" data-noexport="" id="media-type-list0">media-type-list<a class="self-link" href="#media-type-list0"></a></dfn>   = <a data-link-type="dfn" href="#media-type0">media-type</a> *( 1*WSP <a data-link-type="dfn" href="#media-type0">media-type</a> )
+<dfn data-dfn-type="dfn" data-noexport="" id="media-type0">media-type<a class="self-link" href="#media-type0"></a></dfn>        = &lt;type from RFC 2045> "/" &lt;subtype from RFC 2045>
 </pre>
           
 
@@ -2463,7 +2464,7 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
               <li>For each token returned by
         <a data-link-spec="HTML5" data-link-type="dfn" href="http://www.w3.org/TR/html5/#split-a-string-on-spaces" title="split a string on spaces">splitting
         <var>media type list</var> on spaces</a>, if the token matches the
-        grammar for <code><a data-link-type="dfn" href="#media_type">media-type</a></code>, add the token to the
+        grammar for <code><a data-link-type="dfn" href="#media-type0">media-type</a></code>, add the token to the
         <var>set of media types</var>. Otherwise ignore the token.</li>
               
 
@@ -2570,9 +2571,9 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
           
                 <dd>The name of the policy directive that was violated. This will
           contain the <a data-link-type="dfn" href="#security-policy-directive">directive</a> whose enforcement triggered the
-          violation (e.g. "<code><a data-link-type="dfn" href="#script_src">script-src</a></code>") even if that
+          violation (e.g. "<code><a data-link-type="dfn" href="#script-src">script-src</a></code>") even if that
           directive does not explicitly appear in the policy, but is
-          implicitly activated via the <code><a data-link-type="dfn" href="#default_src">default-src</a></code>
+          implicitly activated via the <code><a data-link-type="dfn" href="#default-src">default-src</a></code>
           directive.</dd>
                 
 
@@ -2606,7 +2607,7 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
                 
           
                 <dd>The policy directive that was violated, as it appears in the
-          policy. This will contain the <code><a data-link-type="dfn" href="#default_src">default-src</a></code> directive
+          policy. This will contain the <code><a data-link-type="dfn" href="#default-src">default-src</a></code> directive
           in the case of violations caused by falling back to the
           <a data-link-type="dfn" href="#default-sources">default sources</a> when enforcing
           a directive.</dd>
@@ -2621,13 +2622,13 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
       
             <li>If a specific line or a specific file can be identified as the
       cause of the violation (for example, script execution that violates
-      the <code><a data-link-type="dfn" href="#script_src">script-src</a></code> directive), the user agent MAY add the
+      the <code><a data-link-type="dfn" href="#script-src">script-src</a></code> directive), the user agent MAY add the
       following keys and values to <var>violation</var>:
 
         
               <dl>
           
-                <dt id="violation-report-source-file"><a class="self-link" href="#violation-report-source-file"></a><dfn data-dfn-type="dfn" data-noexport="" id="source_file">source-file<a class="self-link" href="#source_file"></a></dfn></dt>
+                <dt id="violation-report-source-file"><a class="self-link" href="#violation-report-source-file"></a><dfn data-dfn-type="dfn" data-noexport="" id="source-file">source-file<a class="self-link" href="#source-file"></a></dfn></dt>
                 
           
                 <dd>The URL of the resource where the violation occurred,
@@ -2638,7 +2639,7 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
                 <dt id="violation-report-line-number"><a class="self-link" href="#violation-report-line-number"></a>line-number</dt>
                 
           
-                <dd>The line number in <code><a data-link-type="dfn" href="#source_file">source-file</a></code> on which
+                <dd>The line number in <code><a data-link-type="dfn" href="#source-file">source-file</a></code> on which
           the violation occurred.</dd>
                 
 
@@ -2646,7 +2647,7 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
                 <dt id="violation-report-column-number"><a class="self-link" href="#violation-report-column-number"></a>column-number</dt>
                 
           
-                <dd>The column number in <code><a data-link-type="dfn" href="#source_file">source-file</a></code> on which
+                <dd>The column number in <code><a data-link-type="dfn" href="#source-file">source-file</a></code> on which
           the violation occurred.</dd>
                 
         
@@ -2794,8 +2795,8 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
 
 
         <p>A server MAY cause user agents to monitor one policy while enforcing
-  another policy by returning both <code><a data-link-type="dfn" href="#content_security_policy">Content-Security-Policy</a></code>
-  and <code><a data-link-type="dfn" href="#content_security_policy_report_only">Content-Security-Policy-Report-Only</a></code> header fields.
+  another policy by returning both <code><a data-link-type="dfn" href="#content-security-policy">Content-Security-Policy</a></code>
+  and <code><a data-link-type="dfn" href="#content-security-policy-report-only">Content-Security-Policy-Report-Only</a></code> header fields.
   For example, if a server operator may wish to <a data-link-type="dfn" href="#enforce">enforce</a> one policy but
   experiment with a stricter policy, she can monitor the stricter policy while
   enforcing the original policy. Once the server operator is satisfied that
@@ -3301,12 +3302,12 @@ interface <dfn class="idl-code" data-dfn-type="interface" data-export="" data-gl
   
         <ul>
     
-          <li>both the <code><a data-link-type="dfn" href="#script_src">script-src</a></code> and
-    <code><a data-link-type="dfn" href="#object_src">object-src</a></code> directives, or</li>
+          <li>both the <code><a data-link-type="dfn" href="#script-src">script-src</a></code> and
+    <code><a data-link-type="dfn" href="#object-src">object-src</a></code> directives, or</li>
           
 
     
-          <li>include a <code><a data-link-type="dfn" href="#default_src">default-src</a></code> directive, which covers both
+          <li>include a <code><a data-link-type="dfn" href="#default-src">default-src</a></code> directive, which covers both
     scripts and plugins.</li>
           
   
@@ -3333,7 +3334,7 @@ interface <dfn class="idl-code" data-dfn-type="interface" data-export="" data-gl
           
 
 
-          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="base_uri">base-uri<a class="self-link" href="#base_uri"></a></dfn></code> directive restricts the URLs that can
+          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="base-uri">base-uri<a class="self-link" href="#base-uri"></a></dfn></code> directive restricts the URLs that can
     be used to specify the <a data-link-spec="HTML5" data-link-type="dfn" href="http://www.w3.org/TR/html5/#document-base-url">document base URL</a>. The syntax for
     the name and value of the directive are described by the following ABNF
     grammar:</p>
@@ -3341,7 +3342,7 @@ interface <dfn class="idl-code" data-dfn-type="interface" data-export="" data-gl
 
     
           <pre>directive-name    = "base-uri"
-directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
+directive-value   = <a data-link-type="dfn" href="#source-list0">source-list</a>
 </pre>
           
 
@@ -3384,7 +3385,7 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
           
 
 
-          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="child_src">child-src<a class="self-link" href="#child_src"></a></dfn></code> directive governs the creation of
+          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="child-src">child-src<a class="self-link" href="#child-src"></a></dfn></code> directive governs the creation of
     <a data-link-spec="HTML5" data-link-type="dfn" href="http://www.w3.org/TR/html5/#nested-browsing-context">nested browsing contexts</a> as well as Worker execution
     contexts. The syntax for the name and value of the directive are described
     by the following ABNF grammar:</p>
@@ -3392,7 +3393,7 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
 
     
           <pre>directive-name    = "child-src"
-directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
+directive-value   = <a data-link-type="dfn" href="#source-list0">source-list</a>
 </pre>
           
 
@@ -3412,7 +3413,7 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
 
 
             <p>To enforce the <code>child-src</code> directive the user agent MUST
-      enforce the <code><a data-link-type="dfn" href="#frame_src">frame-src</a></code> directive.</p>
+      enforce the <code><a data-link-type="dfn" href="#frame-src">frame-src</a></code> directive.</p>
             
     
           </section>
@@ -3446,14 +3447,14 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
           
 
 
-          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="connect_src">connect-src<a class="self-link" href="#connect_src"></a></dfn></code> directive restricts which URLs the
+          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="connect-src">connect-src<a class="self-link" href="#connect-src"></a></dfn></code> directive restricts which URLs the
     protected resource can load using script interfaces. The syntax for the name
     and value of the directive are described by the following ABNF grammar:</p>
           
 
     
           <pre>directive-name    = "connect-src"
-directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
+directive-value   = <a data-link-type="dfn" href="#source-list0">source-list</a>
 </pre>
           
 
@@ -3527,7 +3528,7 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
             
 
 
-            <pre>Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src</a> example.com</pre>
+            <pre>Content-Security-Policy: <a data-link-type="dfn" href="#connect-src">connect-src</a> example.com</pre>
             
 
 
@@ -3563,14 +3564,14 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
           
 
 
-          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="default_src">default-src<a class="self-link" href="#default_src"></a></dfn></code> directive sets a default
+          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="default-src">default-src<a class="self-link" href="#default-src"></a></dfn></code> directive sets a default
     source list for a number of directives. The syntax for the name and
     value of the directive are described by the following ABNF grammar:</p>
           
 
     
           <pre>directive-name    = "default-src"
-directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
+directive-value   = <a data-link-type="dfn" href="#source-list0">source-list</a>
 </pre>
           
 
@@ -3590,31 +3591,31 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
     
           <ul>
       
-            <li><code><a data-link-type="dfn" href="#child_src">child-src</a></code></li>
+            <li><code><a data-link-type="dfn" href="#child-src">child-src</a></code></li>
             
       
-            <li><code><a data-link-type="dfn" href="#connect_src">connect-src</a></code></li>
+            <li><code><a data-link-type="dfn" href="#connect-src">connect-src</a></code></li>
             
       
-            <li><code><a data-link-type="dfn" href="#font_src">font-src</a></code></li>
+            <li><code><a data-link-type="dfn" href="#font-src">font-src</a></code></li>
             
       
-            <li><code><a data-link-type="dfn" href="#img_src">img-src</a></code></li>
+            <li><code><a data-link-type="dfn" href="#img-src">img-src</a></code></li>
             
       
-            <li><code><a data-link-type="dfn" href="#manifest_src">manifest-src</a></code></li>
+            <li><code><a data-link-type="dfn" href="#manifest-src">manifest-src</a></code></li>
             
       
-            <li><code><a data-link-type="dfn" href="#media_src">media-src</a></code></li>
+            <li><code><a data-link-type="dfn" href="#media-src">media-src</a></code></li>
             
       
-            <li><code><a data-link-type="dfn" href="#object_src">object-src</a></code></li>
+            <li><code><a data-link-type="dfn" href="#object-src">object-src</a></code></li>
             
       
-            <li><code><a data-link-type="dfn" href="#script_src">script-src</a></code></li>
+            <li><code><a data-link-type="dfn" href="#script-src">script-src</a></code></li>
             
       
-            <li><code><a data-link-type="dfn" href="#style_src">style-src</a></code></li>
+            <li><code><a data-link-type="dfn" href="#style-src">style-src</a></code></li>
             
     
           </ul>
@@ -3643,7 +3644,7 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
             
 
 
-            <pre>Content-Security-Policy: <a data-link-type="dfn" href="#default_src">default-src</a> 'self'</pre>
+            <pre>Content-Security-Policy: <a data-link-type="dfn" href="#default-src">default-src</a> 'self'</pre>
             
 
 
@@ -3655,14 +3656,14 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
             
 
 
-            <pre>Content-Security-Policy: <a data-link-type="dfn" href="#default_src">default-src</a> 'self'; <a data-link-type="dfn" href="#script_src">script-src</a> example.com</pre>
+            <pre>Content-Security-Policy: <a data-link-type="dfn" href="#default-src">default-src</a> 'self'; <a data-link-type="dfn" href="#script-src">script-src</a> example.com</pre>
             
 
 
             <p>Under this new policy, fonts, frames, and etc. continue to be load
       from the same origin, but scripts will <em>only</em> load from
       <code>example.com</code>. There’s no inheritance; the
-      <code><a data-link-type="dfn" href="#script_src">script-src</a></code> directive sets the allowed sources of
+      <code><a data-link-type="dfn" href="#script-src">script-src</a></code> directive sets the allowed sources of
       script, and the default list is not used for that resource type.</p>
             
 
@@ -3672,7 +3673,7 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
       <code>'none'</code>, and to build up a policy from there that contains
       only those resource types which are actually in use for the page you’d
       like to protect. If you don’t use webfonts, for instance, there’s no
-      reason to specify a source list for <code><a data-link-type="dfn" href="#font_src">font-src</a></code>;
+      reason to specify a source list for <code><a data-link-type="dfn" href="#font-src">font-src</a></code>;
       specifying only those resource types a page uses ensures that the
       possible attack surface for that page remains as small as possible.</p>
             
@@ -3690,14 +3691,14 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
           
 
 
-          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="font_src">font-src<a class="self-link" href="#font_src"></a></dfn></code> directive restricts from where the
+          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="font-src">font-src<a class="self-link" href="#font-src"></a></dfn></code> directive restricts from where the
     protected resource can load fonts. The syntax for the name and value
     of the directive are described by the following ABNF grammar:</p>
           
 
     
           <pre>directive-name    = "font-src"
-directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
+directive-value   = <a data-link-type="dfn" href="#source-list0">source-list</a>
 </pre>
           
 
@@ -3737,14 +3738,14 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
           
 
 
-          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="form_action">form-action<a class="self-link" href="#form_action"></a></dfn></code> restricts which URLs can be used as
+          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="form-action">form-action<a class="self-link" href="#form-action"></a></dfn></code> restricts which URLs can be used as
     the action of HTML <code><a data-link-type="element" href="https://html.spec.whatwg.org/#the-form-element">form</a></code> elements. The syntax for the name and
     value of the directive are described by the following ABNF grammar:</p>
           
 
     
           <pre>directive-name    = "form-action"
-directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
+directive-value   = <a data-link-type="dfn" href="#source-list0">source-list</a>
 </pre>
           
 
@@ -3777,7 +3778,7 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
 
           <p class="note" role="note">Note: <code>form-action</code> does not fall back to the <a data-link-type="dfn" href="#default-sources" title="default sources">default
     sources</a> when the directive is not defined. That is, a policy that
-    defines <code><a data-link-type="dfn" href="#default_src">default-src</a> 'none'</code> but not
+    defines <code><a data-link-type="dfn" href="#default-src">default-src</a> 'none'</code> but not
     <code>form-action</code> will still allow form submissions to any
     target.</p>
           
@@ -3792,7 +3793,7 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
           
 
 
-          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="frame_ancestors">frame-ancestors<a class="self-link" href="#frame_ancestors"></a></dfn></code> directive indicates whether the
+          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="frame-ancestors">frame-ancestors<a class="self-link" href="#frame-ancestors"></a></dfn></code> directive indicates whether the
     user agent should allow embedding the resource using a
     <code><a data-link-type="element" href="http://www.w3.org/TR/html5/#frame">frame</a></code>, <code><a data-link-type="element" href="http://www.w3.org/TR/html5/#the-iframe-element">iframe</a></code>,
     <code><a data-link-type="element" href="http://www.w3.org/TR/html5/#the-object-element">object</a></code>, <code><a data-link-type="element" href="http://www.w3.org/TR/html5/#the-embed-element">embed</a></code> or
@@ -3808,11 +3809,11 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
           
 
     
-          <pre><dfn data-dfn-type="dfn" data-noexport="" id="ancestor_source_list">ancestor-source-list<a class="self-link" href="#ancestor_source_list"></a></dfn> = [ <a data-link-type="dfn" href="#ancestor_source">ancestor-source</a> *( 1*WSP <a data-link-type="dfn" href="#ancestor_source">ancestor-source</a> ) ] / "'none'"
-<dfn data-dfn-type="dfn" data-noexport="" id="ancestor_source">ancestor-source<a class="self-link" href="#ancestor_source"></a></dfn>      = <a data-link-type="dfn" href="#scheme_source">scheme-source</a> / <a data-link-type="dfn" href="#host_source">host-source</a>
+          <pre><dfn data-dfn-type="dfn" data-noexport="" id="ancestor-source-list">ancestor-source-list<a class="self-link" href="#ancestor-source-list"></a></dfn> = [ <a data-link-type="dfn" href="#ancestor-source">ancestor-source</a> *( 1*WSP <a data-link-type="dfn" href="#ancestor-source">ancestor-source</a> ) ] / "'none'"
+<dfn data-dfn-type="dfn" data-noexport="" id="ancestor-source">ancestor-source<a class="self-link" href="#ancestor-source"></a></dfn>      = <a data-link-type="dfn" href="#scheme-source">scheme-source</a> / <a data-link-type="dfn" href="#host-source">host-source</a>
 
 directive-name  = "frame-ancestors"
-directive-value = <a data-link-type="dfn" href="#ancestor_source_list">ancestor-source-list</a>
+directive-value = <a data-link-type="dfn" href="#ancestor-source-list">ancestor-source-list</a>
 </pre>
           
 
@@ -3930,9 +3931,9 @@ directive-value = <a data-link-type="dfn" href="#ancestor_source_list">ancestor-
           
 
 
-          <p class="note" role="note">Note: <code><a data-link-type="dfn" href="#frame_ancestors">frame-ancestors</a></code> does not fall back to the
+          <p class="note" role="note">Note: <code><a data-link-type="dfn" href="#frame-ancestors">frame-ancestors</a></code> does not fall back to the
     <a data-link-type="dfn" href="#default-sources">default sources</a> when the directive is not defined. That is, a policy
-    that defines <code><a data-link-type="dfn" href="#default_src">default-src</a> 'none'</code> but not
+    that defines <code><a data-link-type="dfn" href="#default-src">default-src</a> 'none'</code> but not
     <code>frame-ancestors</code> will still allow the resource to be framed from
     anywhere.</p>
           
@@ -4010,7 +4011,7 @@ directive-value = <a data-link-type="dfn" href="#ancestor_source_list">ancestor-
             
 
       
-            <pre>Content-Security-Policy: <a data-link-type="dfn" href="#frame_ancestors">frame-ancestors</a> https://alice https://bob
+            <pre>Content-Security-Policy: <a data-link-type="dfn" href="#frame-ancestors">frame-ancestors</a> https://alice https://bob
 </pre>
             
 
@@ -4036,7 +4037,7 @@ directive-value = <a data-link-type="dfn" href="#ancestor_source_list">ancestor-
           
 
 
-          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="frame_src">frame-src<a class="self-link" href="#frame_src"></a></dfn></code> directive is <em>deprecated</em>.
+          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="frame-src">frame-src<a class="self-link" href="#frame-src"></a></dfn></code> directive is <em>deprecated</em>.
     Authors who wish to govern nested browsing contexts SHOULD use the
     <code>child-src</code> directive instead.</p>
           
@@ -4050,7 +4051,7 @@ directive-value = <a data-link-type="dfn" href="#ancestor_source_list">ancestor-
 
     
           <pre>directive-name    = "frame-src"
-directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
+directive-value   = <a data-link-type="dfn" href="#source-list0">source-list</a>
 </pre>
           
 
@@ -4095,14 +4096,14 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
           
 
 
-          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="img_src">img-src<a class="self-link" href="#img_src"></a></dfn></code> directive restricts from where the
+          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="img-src">img-src<a class="self-link" href="#img-src"></a></dfn></code> directive restricts from where the
     protected resource can load images. The syntax for the name and value
     of the directive are described by the following ABNF grammar:</p>
           
 
     
           <pre>directive-name    = "img-src"
-directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
+directive-value   = <a data-link-type="dfn" href="#source-list0">source-list</a>
 </pre>
           
 
@@ -4156,7 +4157,7 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
           
 
 
-          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="manifest_src">manifest-src<a class="self-link" href="#manifest_src"></a></dfn></code> directive restricts which
+          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="manifest-src">manifest-src<a class="self-link" href="#manifest-src"></a></dfn></code> directive restricts which
     application manifest <a data-biblio-type="normative" data-link-type="biblio" href="#biblio-manifest" title="MANIFEST">[MANIFEST]</a> the user agent may apply to the protected
     resource. The syntax for the name and value of the directive are described by
     the following ABNF grammar:</p>
@@ -4164,7 +4165,7 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
 
     
           <pre>directive-name    = "manifest-src"
-directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
+directive-value   = <a data-link-type="dfn" href="#source-list0">source-list</a>
 </pre>
           
 
@@ -4194,7 +4195,7 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
           
 
 
-          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="media_src">media-src<a class="self-link" href="#media_src"></a></dfn></code> directive restricts from where the
+          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="media-src">media-src<a class="self-link" href="#media-src"></a></dfn></code> directive restricts from where the
     protected resource can load video, audio, and associated text tracks.
     The syntax for the name and value of the directive are described by the
     following ABNF grammar:</p>
@@ -4202,7 +4203,7 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
 
     
           <pre>directive-name    = "media-src"
-directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
+directive-value   = <a data-link-type="dfn" href="#source-list0">source-list</a>
 </pre>
           
 
@@ -4245,14 +4246,14 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
           
 
 
-          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="object_src">object-src<a class="self-link" href="#object_src"></a></dfn></code> directive restricts from where
+          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="object-src">object-src<a class="self-link" href="#object-src"></a></dfn></code> directive restricts from where
     the protected resource can load plugins. The syntax for the name and value
     of the directive are described by the following ABNF grammar:</p>
           
 
     
           <pre>directive-name    = "object-src"
-directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
+directive-value   = <a data-link-type="dfn" href="#source-list0">source-list</a>
 </pre>
           
 
@@ -4329,7 +4330,7 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
           
 
 
-          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="plugin_types">plugin-types<a class="self-link" href="#plugin_types"></a></dfn></code> directive restricts the set
+          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="plugin-types">plugin-types<a class="self-link" href="#plugin-types"></a></dfn></code> directive restricts the set
     of plugins that can be invoked by the protected resource by limiting
     the types of resources that can be embedded. The syntax for the name
     and value of the directive are described by the following ABNF
@@ -4432,7 +4433,7 @@ directive-value   = media-type-list
             
 
 
-            <pre>Content-Security-Policy: <a data-link-type="dfn" href="#plugin_types">plugin-types</a> application/pdf</pre>
+            <pre>Content-Security-Policy: <a data-link-type="dfn" href="#plugin-types">plugin-types</a> application/pdf</pre>
             
 
 
@@ -4446,7 +4447,7 @@ directive-value   = media-type-list
             
 
 
-            <pre>Content-Security-Policy: <a data-link-type="dfn" href="#plugin_types">plugin-types</a> application/pdf application/x-shockwave-flash</pre>
+            <pre>Content-Security-Policy: <a data-link-type="dfn" href="#plugin-types">plugin-types</a> application/pdf application/x-shockwave-flash</pre>
             
 
 
@@ -4575,7 +4576,7 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
           
 
 
-          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="reflected_xss">reflected-xss<a class="self-link" href="#reflected_xss"></a></dfn></code> directive instructs a user agent
+          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="reflected-xss">reflected-xss<a class="self-link" href="#reflected-xss"></a></dfn></code> directive instructs a user agent
     to activate or deactivate any heuristics used to filter or block
     reflected cross-site scripting attacks. The syntax for the name and
     value of the directive are described by the following ABNF grammar:</p>
@@ -4675,7 +4676,7 @@ directive-value   = "allow" / "block" / "filter"
           
 
 
-          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="report_uri">report-uri<a class="self-link" href="#report_uri"></a></dfn></code> directive specifies a URL to
+          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="report-uri">report-uri<a class="self-link" href="#report-uri"></a></dfn></code> directive specifies a URL to
     which the user agent sends reports about policy violation. The syntax
     for the name and value of the directive are described by the following
     ABNF grammar:</p>
@@ -4683,8 +4684,8 @@ directive-value   = "allow" / "block" / "filter"
 
     
           <pre>directive-name    = "report-uri"
-directive-value   = <a data-link-type="dfn" href="#uri_reference">uri-reference</a> *( 1*WSP <a data-link-type="dfn" href="#uri_reference">uri-reference</a> )
-<dfn data-dfn-type="dfn" data-noexport="" id="uri_reference">uri-reference<a class="self-link" href="#uri_reference"></a></dfn>     = &lt;URL-reference from RFC 3986>
+directive-value   = <a data-link-type="dfn" href="#uri-reference">uri-reference</a> *( 1*WSP <a data-link-type="dfn" href="#uri-reference">uri-reference</a> )
+<dfn data-dfn-type="dfn" data-noexport="" id="uri-reference">uri-reference<a class="self-link" href="#uri-reference"></a></dfn>     = &lt;URL-reference from RFC 3986>
 </pre>
           
 
@@ -4722,8 +4723,8 @@ directive-value   = <a data-link-type="dfn" href="#uri_reference">uri-reference<
 
     
           <pre>directive-name    = "sandbox"
-directive-value   = "" / sandbox-token *( 1*WSP <a data-link-type="dfn" href="#sandbox_token">sandbox-token</a> )
-<dfn data-dfn-type="dfn" data-noexport="" id="sandbox_token">sandbox-token<a class="self-link" href="#sandbox_token"></a></dfn>     = &lt;token from RFC 7230>
+directive-value   = "" / sandbox-token *( 1*WSP <a data-link-type="dfn" href="#sandbox-token">sandbox-token</a> )
+<dfn data-dfn-type="dfn" data-noexport="" id="sandbox-token">sandbox-token<a class="self-link" href="#sandbox-token"></a></dfn>     = &lt;token from RFC 7230>
 </pre>
           
 
@@ -4846,7 +4847,7 @@ directive-value   = "" / sandbox-token *( 1*WSP <a data-link-type="dfn" href="#s
           
 
 
-          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="script_src">script-src<a class="self-link" href="#script_src"></a></dfn></code> directive restricts which scripts the
+          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="script-src">script-src<a class="self-link" href="#script-src"></a></dfn></code> directive restricts which scripts the
     protected resource can execute. The directive also controls other resources,
     such as XSLT style sheets <a data-biblio-type="normative" data-link-type="biblio" href="#biblio-xslt" title="XSLT">[XSLT]</a>, which can cause the user agent to
     execute script. The syntax for the name and value of the directive are
@@ -4855,7 +4856,7 @@ directive-value   = "" / sandbox-token *( 1*WSP <a data-link-type="dfn" href="#s
 
     
           <pre>directive-name    = "script-src"
-directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
+directive-value   = <a data-link-type="dfn" href="#source-list0">source-list</a>
 </pre>
           
 
@@ -4870,7 +4871,7 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
 
           <p>If <code>'unsafe-inline'</code> is <strong>not</strong> in the
     list of <a data-link-type="dfn" href="#allowed-script-sources">allowed script sources</a>, or if at least one
-    <code><a data-link-type="dfn" href="#nonce_source">nonce-source</a></code> or <code><a data-link-type="dfn" href="#hash_source">hash-source</a></code> is
+    <code><a data-link-type="dfn" href="#nonce-source">nonce-source</a></code> or <code><a data-link-type="dfn" href="#hash-source">hash-source</a></code> is
     present in the list of <a data-link-type="dfn" href="#allowed-script-sources">allowed script sources</a>:</p>
           
 
@@ -4988,7 +4989,7 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
             
 
 
-            <p>The <code><a data-link-type="dfn" href="#script_src">script-src</a></code> directive lets developers specify
+            <p>The <code><a data-link-type="dfn" href="#script-src">script-src</a></code> directive lets developers specify
       exactly which script elements on a page were intentionally included
       for execution. Ideally, developers would avoid inline script entirely
       and whitelist scripts by URL. However, in some cases, removing inline
@@ -5003,8 +5004,8 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
             
 
       
-            <pre>Content-Security-Policy: <a data-link-type="dfn" href="#default_src">default-src</a> 'self';
-                         <a data-link-type="dfn" href="#script_src">script-src</a> 'self' https://example.com 'nonce-<em>$RANDOM</em>'
+            <pre>Content-Security-Policy: <a data-link-type="dfn" href="#default-src">default-src</a> 'self';
+                         <a data-link-type="dfn" href="#script-src">script-src</a> 'self' https://example.com 'nonce-<em>$RANDOM</em>'
 </pre>
             
 
@@ -5017,8 +5018,8 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
             
 
       
-            <pre>Content-Security-Policy: <a data-link-type="dfn" href="#default_src">default-src</a> 'self';
-                         <a data-link-type="dfn" href="#script_src">script-src</a> 'self' https://example.com 'nonce-Nc3n83cnSAd3wc3Sasdfn939hc3'
+            <pre>Content-Security-Policy: <a data-link-type="dfn" href="#default-src">default-src</a> 'self';
+                         <a data-link-type="dfn" href="#script-src">script-src</a> 'self' https://example.com 'nonce-Nc3n83cnSAd3wc3Sasdfn939hc3'
 </pre>
             
 
@@ -5082,7 +5083,7 @@ alert("Allowed because nonce is valid.")
             
 
 
-            <p>The <code><a data-link-type="dfn" href="#script_src">script-src</a></code> directive lets developers whitelist a
+            <p>The <code><a data-link-type="dfn" href="#script-src">script-src</a></code> directive lets developers whitelist a
       particular inline script by specifying its hash as an allowed source
       of script.</p>
             
@@ -5094,8 +5095,8 @@ alert("Allowed because nonce is valid.")
             
 
       
-            <pre>Content-Security-Policy: <a data-link-type="dfn" href="#default_src">default-src</a> 'self';
-                         <a data-link-type="dfn" href="#script_src">script-src</a> 'self' https://example.com 'sha256-<var>base64 encoded hash</var>'
+            <pre>Content-Security-Policy: <a data-link-type="dfn" href="#default-src">default-src</a> 'self';
+                         <a data-link-type="dfn" href="#script-src">script-src</a> 'self' https://example.com 'sha256-<var>base64 encoded hash</var>'
 </pre>
             
 
@@ -5124,7 +5125,7 @@ alert("Allowed because nonce is valid.")
             
 
       
-            <pre>Content-Security-Policy: <a data-link-type="dfn" href="#script_src">script-src</a> 'sha256-YWIzOWNiNzJjNDRlYzc4MTgwMDhmZDlkOWI0NTAyMjgyY2MyMWJlMWUyNjc1ODJlYWJhNjU5MGU4NmZmNGU3OAo='
+            <pre>Content-Security-Policy: <a data-link-type="dfn" href="#script-src">script-src</a> 'sha256-YWIzOWNiNzJjNDRlYzc4MTgwMDhmZDlkOWI0NTAyMjgyY2MyMWJlMWUyNjc1ODJlYWJhNjU5MGU4NmZmNGU3OAo='
 </pre>
             
 
@@ -5172,14 +5173,14 @@ alert('Hello, world.');
           
 
 
-          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="style_src">style-src<a class="self-link" href="#style_src"></a></dfn></code> directive restricts which styles the
+          <p>The <code><dfn data-dfn-type="dfn" data-noexport="" id="style-src">style-src<a class="self-link" href="#style-src"></a></dfn></code> directive restricts which styles the
     user may applies to the protected resource. The syntax for the name and
     value of the directive are described by the following ABNF grammar:</p>
           
 
     
           <pre>directive-name    = "style-src"
-directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
+directive-value   = <a data-link-type="dfn" href="#source-list0">source-list</a>
 </pre>
           
 
@@ -5193,7 +5194,7 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
 
           <p>If <code>'unsafe-inline'</code> is <strong>not</strong> in the
     list of <a data-link-type="dfn" href="#allowed-style-sources">allowed style sources</a>, or if at least one
-    <code><a data-link-type="dfn" href="#nonce_source">nonce-source</a></code> or <code><a data-link-type="dfn" href="#hash_source">hash-source</a></code>
+    <code><a data-link-type="dfn" href="#nonce-source">nonce-source</a></code> or <code><a data-link-type="dfn" href="#hash-source">hash-source</a></code>
     is present in the list of <a data-link-type="dfn" href="#allowed-style-sources">allowed style sources</a>:</p>
           
 
@@ -5289,7 +5290,7 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
 
 
           <p class="note" role="note">Note: The <code>style-src</code> directive does not restrict the
-    use of XSLT. XSLT is restricted by the <code><a data-link-type="dfn" href="#script_src">script-src</a></code>
+    use of XSLT. XSLT is restricted by the <code><a data-link-type="dfn" href="#script-src">script-src</a></code>
     directive because the security consequences of including an untrusted
     XSLT stylesheet are similar to those incurred by including an
     untrusted script.</p>
@@ -5362,7 +5363,7 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
       A server wishes to load resources only from its own origin:
 
 
-            <pre>Content-Security-Policy: <a data-link-type="dfn" href="#default_src">default-src</a> 'self'</pre>
+            <pre>Content-Security-Policy: <a data-link-type="dfn" href="#default-src">default-src</a> 'self'</pre>
             
     
           </div>
@@ -5377,9 +5378,9 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
 
       
             <pre>Content-Security-Policy:
-    <a data-link-type="dfn" href="#default_src">default-src</a> 'self'; img-src *;
-    <a data-link-type="dfn" href="#object_src">object-src</a> media1.example.com media2.example.com *.cdn.example.com;
-    <a data-link-type="dfn" href="#script_src">script-src</a> trustedscripts.example.com
+    <a data-link-type="dfn" href="#default-src">default-src</a> 'self'; img-src *;
+    <a data-link-type="dfn" href="#object-src">object-src</a> media1.example.com media2.example.com *.cdn.example.com;
+    <a data-link-type="dfn" href="#script-src">script-src</a> trustedscripts.example.com
 </pre>
             
     
@@ -5393,7 +5394,7 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
       content requests:
 
 
-            <pre>Content-Security-Policy: <a data-link-type="dfn" href="#default_src">default-src</a> https: 'unsafe-inline' 'unsafe-eval'</pre>
+            <pre>Content-Security-Policy: <a data-link-type="dfn" href="#default-src">default-src</a> https: 'unsafe-inline' 'unsafe-eval'</pre>
             
 
 
@@ -5413,7 +5414,7 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
       elements it intentionally inserted inline:
 
 
-            <pre>Content-Security-Policy: <a data-link-type="dfn" href="#script_src">script-src</a> 'self' 'nonce-<em>$RANDOM</em>';</pre>
+            <pre>Content-Security-Policy: <a data-link-type="dfn" href="#script-src">script-src</a> 'self' 'nonce-<em>$RANDOM</em>';</pre>
             
 
 
@@ -5450,7 +5451,7 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
           
 
 
-          <pre><a data-link-type="dfn" href="#default_src">default-src</a> 'self'; <a data-link-type="dfn" href="#report_uri">report-uri</a> http://example.org/csp-report.cgi</pre>
+          <pre><a data-link-type="dfn" href="#default-src">default-src</a> 'self'; <a data-link-type="dfn" href="#report-uri">report-uri</a> http://example.org/csp-report.cgi</pre>
           
 
 
@@ -5488,7 +5489,7 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
           
 
 
-          <p>The <code><a data-link-type="dfn" href="#style_src">style-src</a></code> directive restricts the locations from
+          <p>The <code><a data-link-type="dfn" href="#style-src">style-src</a></code> directive restricts the locations from
     which the protected resource can load styles. However, if the user agent uses a
     lax CSS parsing algorithm, an attacker might be able to trick the user
     agent into accepting malicious "stylesheets" hosted by an otherwise
@@ -5536,18 +5537,18 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
         <h2 class="heading settled" data-level="10" id="implementation-considerations"><span class="secno">10. </span><span class="content">Implementation Considerations</span><a class="self-link" href="#implementation-considerations"></a></h2>
 
 
-        <p>The <code><a data-link-type="dfn" href="#content_security_policy">Content-Security-Policy</a></code> header is an end-to-end
+        <p>The <code><a data-link-type="dfn" href="#content-security-policy">Content-Security-Policy</a></code> header is an end-to-end
   header. It is processed and enforced at the client and, therefore,
   SHOULD NOT be modified or removed by proxies or other intermediaries not
   in the same administrative domain as the resource.</p>
 
 
         <p>The originating administrative domain for a resource might wish to
-  apply a <code><a data-link-type="dfn" href="#content_security_policy">Content-Security-Policy</a></code> header outside of the
+  apply a <code><a data-link-type="dfn" href="#content-security-policy">Content-Security-Policy</a></code> header outside of the
   immediate context of an application. For example, a large organization
   might have many resources and applications managed by different
   individuals or teams but all subject to a uniform organizational
-  standard. In such situations, a <code><a data-link-type="dfn" href="#content_security_policy">Content-Security-Policy</a></code>
+  standard. In such situations, a <code><a data-link-type="dfn" href="#content-security-policy">Content-Security-Policy</a></code>
   header might be added or combined with an existing one at a network-edge
   security gateway device or web application firewall. To enforce multiple
   policies, the administrator SHOULD combine the policy into a single header.
@@ -5571,11 +5572,11 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
   by upstream resource owners.</p>
 
 
-        <p>Interactions between the <code><a data-link-type="dfn" href="#default_src">default-src</a></code> and other directives
+        <p>Interactions between the <code><a data-link-type="dfn" href="#default-src">default-src</a></code> and other directives
   SHOULD be given special consideration when combining policies. If none
-  of the policies contains a <code><a data-link-type="dfn" href="#default_src">default-src</a></code> directive, adding new
+  of the policies contains a <code><a data-link-type="dfn" href="#default-src">default-src</a></code> directive, adding new
   src directives results in a more restrictive policy. However, if one or
-  more of the input policies contain a <code><a data-link-type="dfn" href="#default_src">default-src</a></code> directive,
+  more of the input policies contain a <code><a data-link-type="dfn" href="#default-src">default-src</a></code> directive,
   adding new src directives might result in a less restrictive policy, for
   example, if the more specific directive contains a more permissive set of
   allowed origins.</p>
@@ -5601,19 +5602,19 @@ directive-value   = <a data-link-type="dfn" href="#source_list">source-list</a>
     the following headers:
 
     
-          <pre>Content-Security-Policy: <a data-link-type="dfn" href="#frame_ancestors">frame-ancestors</a> https://example.com/ 
-Content-Security-Policy: <a data-link-type="dfn" href="#default_src">default-src</a> https:; report-uri https://example.com/
+          <pre>Content-Security-Policy: <a data-link-type="dfn" href="#frame-ancestors">frame-ancestors</a> https://example.com/ 
+Content-Security-Policy: <a data-link-type="dfn" href="#default-src">default-src</a> https:; report-uri https://example.com/
 </pre>
           
 
 
           <p>would send violation reports for <code>http</code> resources, but would not
-    send violation reports for <code><a data-link-type="dfn" href="#frame_ancestors">frame-ancestors</a></code> violations.
+    send violation reports for <code><a data-link-type="dfn" href="#frame-ancestors">frame-ancestors</a></code> violations.
     Note also that combining them via '<code>,</code>' into the single header</p>
           
 
     
-          <pre>Content-Security-Policy: <a data-link-type="dfn" href="#frame_ancestors">frame-ancestors</a> https://example.com/, <a data-link-type="dfn" href="#default_src">default-src</a> https:; report-uri https://example.com/
+          <pre>Content-Security-Policy: <a data-link-type="dfn" href="#frame-ancestors">frame-ancestors</a> https://example.com/, <a data-link-type="dfn" href="#default-src">default-src</a> https:; report-uri https://example.com/
 </pre>
           
 
@@ -5640,7 +5641,7 @@ Content-Security-Policy: <a data-link-type="dfn" href="#default_src">default-src
         <ol>
     
           <li>
-      The <a data-link-type="dfn" href="#frame_ancestors">frame-ancestor</a> directive MUST take effect before a document is
+      The <a data-link-type="dfn" href="#frame-ancestors">frame-ancestor</a> directive MUST take effect before a document is
       loaded into a <a data-link-type="dfn" href="http://www.w3.org/TR/html5/#nested-browsing-context">nested browsing context</a>, and certainly before script
       is potentially executed. One way to approach this constraint is to perform
       the ancestor check defined in <a data-section="" href="#directive-frame-ancestors">§7.7 frame-ancestors</a> while parsing
@@ -5735,7 +5736,7 @@ Content-Security-Policy: style-src 'none'
             <dt>Specification document</dt>
             
       
-            <dd>This specification (See <code><a data-link-type="dfn" href="#content_security_policy">Content-Security-Policy</a></code>
+            <dd>This specification (See <code><a data-link-type="dfn" href="#content-security-policy">Content-Security-Policy</a></code>
       Header Field)</dd>
             
     
@@ -5785,7 +5786,7 @@ Content-Security-Policy: style-src 'none'
             
       
             <dd>This specification (See
-      <code><a data-link-type="dfn" href="#content_security_policy_report_only">Content-Security-Policy-Report-Only</a></code> Header Field)</dd>
+      <code><a data-link-type="dfn" href="#content-security-policy-report-only">Content-Security-Policy-Report-Only</a></code> Header Field)</dd>
             
     
           </dl>
@@ -5855,7 +5856,7 @@ Content-Security-Policy: style-src 'none'
   <a href="https://tools.ietf.org/id/draft-hodges-websec-framework-reqs">draft-hodges-websec-framework-reqs</a>.</p>
 
 
-        <p>A portion of the <code><a data-link-type="dfn" href="#frame_ancestors">frame-ancestors</a></code> directive was
+        <p>A portion of the <code><a data-link-type="dfn" href="#frame-ancestors">frame-ancestors</a></code> directive was
   originally developed as <code>X-Frame-Options</code>. [RFC7034]</p>
 </section>
 
@@ -6018,10 +6019,11 @@ Content-Security-Policy: style-src 'none'
       <li>allowRedirects, <a href="#dom-securitypolicysourcelistdirective-allowredirects" title="section 6.1">6.1</a></li>
       <li>allowRequest(request), <a href="#dom-securitypolicy-allowrequestrequest" title="section 6.1">6.1</a></li>
       <li>ALPHA, <a href="#alpha" title="section 2.4">2.4</a></li>
-      <li>ancestor-source, <a href="#ancestor_source" title="section 7.7">7.7</a></li>
-      <li>ancestor-source-list, <a href="#ancestor_source_list" title="section 7.7">7.7</a></li>
-      <li>base64-value, <a href="#base64_value" title="section 4.2">4.2</a></li>
-      <li>base-uri, <a href="#base_uri" title="section 7.1">7.1</a></li>
+      <li>ancestor-source, <a href="#ancestor-source" title="section 7.7">7.7</a></li>
+      <li>ancestor-source-list, <a href="#ancestor-source-list" title="section 7.7">7.7</a></li>
+      <li>base64url-value, <a href="#base64url-value" title="section 4.2">4.2</a></li>
+      <li>base64-value, <a href="#base64-value" title="section 4.2">4.2</a></li>
+      <li>base-uri, <a href="#base-uri" title="section 7.1">7.1</a></li>
       <li>blockedURL
         <ul>
           <li>attribute for SecurityPolicyViolationEvent, <a href="#dom-securitypolicyviolationevent-blockedurl" title="section 6.2">6.2</a></li>
@@ -6030,7 +6032,7 @@ Content-Security-Policy: style-src 'none'
       </li>
       <li>callable, <a href="#callable" title="section 2.3">2.3</a></li>
       <li>callers, <a href="#callers" title="section 2.3">2.3</a></li>
-      <li>child-src, <a href="#child_src" title="section 7.2">7.2</a></li>
+      <li>child-src, <a href="#child-src" title="section 7.2">7.2</a></li>
       <li>columnNumber
         <ul>
           <li>attribute for SecurityPolicyViolationEvent, <a href="#dom-securitypolicyviolationevent-columnnumber" title="section 6.2">6.2</a></li>
@@ -6039,15 +6041,15 @@ Content-Security-Policy: style-src 'none'
       </li>
       <li>conformant server, <a href="#conformant-server" title="section Unnumbered section">Unnumbered section</a></li>
       <li>conformant user agent, <a href="#conformant-user-agent" title="section Unnumbered section">Unnumbered section</a></li>
-      <li>connect-src, <a href="#connect_src" title="section 7.3">7.3</a></li>
-      <li>Content-Security-Policy, <a href="#content_security_policy" title="section 3.1">3.1</a></li>
-      <li>Content-Security-Policy-Report-Only, <a href="#content_security_policy_report_only" title="section 3.2">3.2</a></li>
+      <li>connect-src, <a href="#connect-src" title="section 7.3">7.3</a></li>
+      <li>Content-Security-Policy, <a href="#content-security-policy" title="section 3.1">3.1</a></li>
+      <li>Content-Security-Policy-Report-Only, <a href="#content-security-policy-report-only" title="section 3.2">3.2</a></li>
       <li>Content Security Policy task
           source, <a href="#content-security-policy-task-source" title="section 4.4">4.4</a></li>
       <li>CSP, <a href="#csp" title="section 3.4">3.4</a></li>
-      <li>csp-header-value, <a href="#csp_header_value" title="section 3.4">3.4</a></li>
+      <li>csp-header-value, <a href="#csp-header-value" title="section 3.4">3.4</a></li>
       <li>default sources, <a href="#default-sources" title="section 7.4">7.4</a></li>
-      <li>default-src, <a href="#default_src" title="section 7.4">7.4</a></li>
+      <li>default-src, <a href="#default-src" title="section 7.4">7.4</a></li>
       <li>digest of element’s content, <a href="#digest-of-elements-content" title="section 4.2.5">4.2.5</a></li>
       <li>DIGIT, <a href="#digit" title="section 2.4">2.4</a></li>
       <li>directive
@@ -6058,10 +6060,10 @@ Content-Security-Policy: style-src 'none'
       </li>
       <li>directiveName, <a href="#dom-securitypolicysourcelistdirective-securitypolicysourcelistdirectivedirectivename-directivevalue-directivename" title="section 6.1">6.1</a></li>
       <li>directive name, <a href="#security-policy-directive-name" title="section 2.1">2.1</a></li>
-      <li>directive-name, <a href="#directive_name" title="section 4.1">4.1</a></li>
+      <li>directive-name, <a href="#directive-name" title="section 4.1">4.1</a></li>
       <li>directives, <a href="#dom-securitypolicy-directives" title="section 6.1">6.1</a></li>
-      <li>directive-token, <a href="#directive_token" title="section 4.1">4.1</a></li>
-      <li>directive-value, <a href="#directive_value" title="section 4.1">4.1</a></li>
+      <li>directive-token, <a href="#directive-token" title="section 4.1">4.1</a></li>
+      <li>directive-value, <a href="#directive-value" title="section 4.1">4.1</a></li>
       <li>directiveValue, <a href="#dom-securitypolicysourcelistdirective-securitypolicysourcelistdirectivedirectivename-directivevalue-directivevalue" title="section 6.1">6.1</a></li>
       <li>directive value, <a href="#security-policy-directive-value" title="section 2.1">2.1</a></li>
       <li>documentURL
@@ -6080,34 +6082,34 @@ Content-Security-Policy: style-src 'none'
       <li>enforce, <a href="#enforce" title="section 5">5</a></li>
       <li>eventInitDict, <a href="#dom-securitypolicyviolationevent-securitypolicyviolationeventtype-eventinitdict-eventinitdict" title="section 6.2">6.2</a></li>
       <li>fire a violation event, <a href="#fire-a-violation-event" title="section 6.4">6.4</a></li>
-      <li>font-src, <a href="#font_src" title="section 7.5">7.5</a></li>
-      <li>form-action, <a href="#form_action" title="section 7.6">7.6</a></li>
-      <li>frame-ancestors, <a href="#frame_ancestors" title="section 7.7">7.7</a></li>
-      <li>frame-src, <a href="#frame_src" title="section 7.8">7.8</a></li>
+      <li>font-src, <a href="#font-src" title="section 7.5">7.5</a></li>
+      <li>form-action, <a href="#form-action" title="section 7.6">7.6</a></li>
+      <li>frame-ancestors, <a href="#frame-ancestors" title="section 7.7">7.7</a></li>
+      <li>frame-src, <a href="#frame-src" title="section 7.8">7.8</a></li>
       <li>generate a violation report object, <a href="#generate-a-violation-report-object" title="section 4.4">4.4</a></li>
       <li>generating a violation report object, <a href="#generate-a-violation-report-object" title="section 4.4">4.4</a></li>
       <li>globally unique identifier, <a href="#globally-unique-identifier" title="section 2.2">2.2</a></li>
       <li>hash, <a href="#dom-securitypolicysourcehash-hash" title="section 6.1">6.1</a></li>
-      <li>hash-algo, <a href="#hash_algo" title="section 4.2">4.2</a></li>
-      <li>hash-source, <a href="#hash_source" title="section 4.2">4.2</a></li>
-      <li>hash-value, <a href="#hash_value" title="section 4.2">4.2</a></li>
+      <li>hash-algo, <a href="#hash-algo" title="section 4.2">4.2</a></li>
+      <li>hash-source, <a href="#hash-source" title="section 4.2">4.2</a></li>
+      <li>hash-value, <a href="#hash-value" title="section 4.2">4.2</a></li>
       <li>host, <a href="#dom-securitypolicysourceurl-host" title="section 6.1">6.1</a></li>
-      <li>host-char, <a href="#host_char" title="section 4.2">4.2</a></li>
-      <li>host-part, <a href="#host_part" title="section 4.2">4.2</a></li>
-      <li>host-source, <a href="#host_source" title="section 4.2">4.2</a></li>
+      <li>host-char, <a href="#host-char" title="section 4.2">4.2</a></li>
+      <li>host-part, <a href="#host-part" title="section 4.2">4.2</a></li>
+      <li>host-source, <a href="#host-source" title="section 4.2">4.2</a></li>
       <li>hostWildcard, <a href="#dom-securitypolicysourceurl-hostwildcard" title="section 6.1">6.1</a></li>
       <li>HTTP 200 response, <a href="#http-200-response" title="section 2.2">2.2</a></li>
-      <li>img-src, <a href="#img_src" title="section 7.9">7.9</a></li>
+      <li>img-src, <a href="#img-src" title="section 7.9">7.9</a></li>
       <li>JSON object, <a href="#json-object" title="section 2.2">2.2</a></li>
       <li>JSON stringification, <a href="#json-stringification" title="section 2.2">2.2</a></li>
-      <li>keyword-source, <a href="#keyword_source" title="section 4.2">4.2</a></li>
+      <li>keyword-source, <a href="#keyword-source" title="section 4.2">4.2</a></li>
       <li>lineNumber
         <ul>
           <li>attribute for SecurityPolicyViolationEvent, <a href="#dom-securitypolicyviolationevent-linenumber" title="section 6.2">6.2</a></li>
           <li>dict-member for SecurityPolicyViolationEventInit, <a href="#dom-securitypolicyviolationeventinit-linenumber" title="section 6.3">6.3</a></li>
         </ul>
       </li>
-      <li>manifest-src, <a href="#manifest_src" title="section 7.10">7.10</a></li>
+      <li>manifest-src, <a href="#manifest-src" title="section 7.10">7.10</a></li>
       <li>match a media type list, <a href="#match-a-media-type-list" title="section 4.3.2">4.3.2</a></li>
       <li>match a source expression, <a href="#match-a-source-expression" title="section 4.2.2">4.2.2</a></li>
       <li>match a source list, <a href="#match-a-source-list" title="section 4.2.2">4.2.2</a></li>
@@ -6124,11 +6126,11 @@ Content-Security-Policy: style-src 'none'
           <li>method for SecurityPolicySourceListDirective, <a href="#dom-securitypolicysourcelistdirective-matchesurlurl" title="section 6.1">6.1</a></li>
         </ul>
       </li>
-      <li>media-src, <a href="#media_src" title="section 7.11">7.11</a></li>
+      <li>media-src, <a href="#media-src" title="section 7.11">7.11</a></li>
       <li>media type, <a href="#media-type" title="section 4.3">4.3</a></li>
-      <li>media-type, <a href="#media_type" title="section 4.3">4.3</a></li>
+      <li>media-type, <a href="#media-type0" title="section 4.3">4.3</a></li>
       <li>media type list, <a href="#media-type-list" title="section 4.3">4.3</a></li>
-      <li>media-type-list, <a href="#media_type_list" title="section 4.3">4.3</a></li>
+      <li>media-type-list, <a href="#media-type-list0" title="section 4.3">4.3</a></li>
       <li>mode
         <ul>
           <li>argument for SecurityPolicy/SecurityPolicy(policy,, mode), <a href="#dom-securitypolicy-securitypolicypolicy-mode-mode" title="section 6.1">6.1</a></li>
@@ -6153,9 +6155,9 @@ Content-Security-Policy: style-src 'none'
           <li>attribute for SecurityPolicySourceNonce, <a href="#dom-securitypolicysourcenonce-nonce" title="section 6.1">6.1</a></li>
         </ul>
       </li>
-      <li>nonce-source, <a href="#nonce_source" title="section 4.2">4.2</a></li>
-      <li>nonce-value, <a href="#nonce_value" title="section 4.2">4.2</a></li>
-      <li>object-src, <a href="#object_src" title="section 7.12">7.12</a></li>
+      <li>nonce-source, <a href="#nonce-source" title="section 4.2">4.2</a></li>
+      <li>nonce-value, <a href="#nonce-value" title="section 4.2">4.2</a></li>
+      <li>object-src, <a href="#object-src" title="section 7.12">7.12</a></li>
       <li>origin, <a href="#origin" title="section 2.2">2.2</a></li>
       <li>originalPolicy
         <ul>
@@ -6167,17 +6169,17 @@ Content-Security-Policy: style-src 'none'
       <li>parse a source list, <a href="#parse-a-source-list" title="section 4.2.1">4.2.1</a></li>
       <li>parse the policy, <a href="#parse-the-policy" title="section 4.1.1">4.1.1</a></li>
       <li>path, <a href="#dom-securitypolicysourceurl-path" title="section 6.1">6.1</a></li>
-      <li>path-part, <a href="#path_part" title="section 4.2">4.2</a></li>
-      <li>plugin-types, <a href="#plugin_types" title="section 7.13">7.13</a></li>
+      <li>path-part, <a href="#path-part" title="section 4.2">4.2</a></li>
+      <li>plugin-types, <a href="#plugin-types" title="section 7.13">7.13</a></li>
       <li>policy
         <ul>
           <li>definition of, <a href="#security-policy" title="section 2.1">2.1</a></li>
           <li>argument for SecurityPolicy/SecurityPolicy(policy,, mode), <a href="#dom-securitypolicy-securitypolicypolicy-mode-policy" title="section 6.1">6.1</a></li>
         </ul>
       </li>
-      <li>policy-token, <a href="#policy_token" title="section 4.1">4.1</a></li>
+      <li>policy-token, <a href="#policy-token" title="section 4.1">4.1</a></li>
       <li>port, <a href="#dom-securitypolicysourceurl-port" title="section 6.1">6.1</a></li>
-      <li>port-part, <a href="#port_part" title="section 4.2">4.2</a></li>
+      <li>port-part, <a href="#port-part" title="section 4.2">4.2</a></li>
       <li>portWildcard, <a href="#dom-securitypolicysourceurl-portwildcard" title="section 6.1">6.1</a></li>
       <li>protected resource, <a href="#protected-resource" title="section 2.1">2.1</a></li>
       <li>referrer
@@ -6187,20 +6189,20 @@ Content-Security-Policy: style-src 'none'
           <li>definition of, <a href="#referrer" title="section 7.14">7.14</a></li>
         </ul>
       </li>
-      <li>reflected-xss, <a href="#reflected_xss" title="section 7.15">7.15</a></li>
+      <li>reflected-xss, <a href="#reflected-xss" title="section 7.15">7.15</a></li>
       <li>report a violation, <a href="#report-a-violation" title="section 4.4">4.4</a></li>
       <li>reportingEndpoint, <a href="#dom-securitypolicy-reportingendpoint" title="section 6.1">6.1</a></li>
-      <li>report-uri, <a href="#report_uri" title="section 7.16">7.16</a></li>
+      <li>report-uri, <a href="#report-uri" title="section 7.16">7.16</a></li>
       <li>representation, <a href="#resource-representation" title="section 2.2">2.2</a></li>
       <li>request, <a href="#dom-securitypolicy-allowrequest-request" title="section 6.1">6.1</a></li>
       <li>resource representation, <a href="#resource-representation" title="section 2.2">2.2</a></li>
       <li>runs a worker, <a href="#runs-a-worker" title="section 2.3">2.3</a></li>
       <li>sandbox, <a href="#sandbox" title="section 7.17">7.17</a></li>
-      <li>sandbox-token, <a href="#sandbox_token" title="section 7.17">7.17</a></li>
+      <li>sandbox-token, <a href="#sandbox-token" title="section 7.17">7.17</a></li>
       <li>scheme, <a href="#dom-securitypolicysourceurl-scheme" title="section 6.1">6.1</a></li>
-      <li>scheme-part, <a href="#scheme_part" title="section 4.2">4.2</a></li>
-      <li>scheme-source, <a href="#scheme_source" title="section 4.2">4.2</a></li>
-      <li>script-src, <a href="#script_src" title="section 7.18">7.18</a></li>
+      <li>scheme-part, <a href="#scheme-part" title="section 4.2">4.2</a></li>
+      <li>scheme-source, <a href="#scheme-source" title="section 4.2">4.2</a></li>
+      <li>script-src, <a href="#script-src" title="section 7.18">7.18</a></li>
       <li>SecurityPolicy, <a href="#securitypolicy" title="section 6.1">6.1</a></li>
       <li>security policy, <a href="#security-policy" title="section 2.1">2.1</a></li>
       <li>SecurityPolicyDirective, <a href="#securitypolicydirective" title="section 6.1">6.1</a></li>
@@ -6224,10 +6226,10 @@ Content-Security-Policy: style-src 'none'
       <li>SecurityPolicyViolationEvent(type, eventInitDict), <a href="#dom-securitypolicyviolationevent-securitypolicyviolationeventtype-eventinitdict" title="section 6.2">6.2</a></li>
       <li>send violation reports, <a href="#send-violation-reports" title="section 4.4">4.4</a></li>
       <li>set of report URLs, <a href="#set-of-report-urls" title="section 7.16">7.16</a></li>
-      <li>SHA-256, <a href="#sha_256" title="section 2.2">2.2</a></li>
-      <li>SHA-384, <a href="#sha_384" title="section 2.2">2.2</a></li>
-      <li>SHA-512, <a href="#sha_512" title="section 2.2">2.2</a></li>
-      <li>source-expression, <a href="#source_expression" title="section 4.2">4.2</a></li>
+      <li>SHA-256, <a href="#sha-256" title="section 2.2">2.2</a></li>
+      <li>SHA-384, <a href="#sha-384" title="section 2.2">2.2</a></li>
+      <li>SHA-512, <a href="#sha-512" title="section 2.2">2.2</a></li>
+      <li>source-expression, <a href="#source-expression0" title="section 4.2">4.2</a></li>
       <li>sourceExpression
         <ul>
           <li>argument for SecurityPolicySourceURL/SecurityPolicySourceURL(sourceExpression), <a href="#dom-securitypolicysourceurl-securitypolicysourceurlsourceexpression-sourceexpression" title="section 6.1">6.1</a></li>
@@ -6236,23 +6238,23 @@ Content-Security-Policy: style-src 'none'
         </ul>
       </li>
       <li>source expression, <a href="#source-expression" title="section 4.2">4.2</a></li>
-      <li>source-file, <a href="#source_file" title="section 4.4">4.4</a></li>
+      <li>source-file, <a href="#source-file" title="section 4.4">4.4</a></li>
       <li>sourceFile
         <ul>
           <li>attribute for SecurityPolicyViolationEvent, <a href="#dom-securitypolicyviolationevent-sourcefile" title="section 6.2">6.2</a></li>
           <li>dict-member for SecurityPolicyViolationEventInit, <a href="#dom-securitypolicyviolationeventinit-sourcefile" title="section 6.3">6.3</a></li>
         </ul>
       </li>
-      <li>source-list, <a href="#source_list" title="section 4.2">4.2</a></li>
+      <li>source-list, <a href="#source-list0" title="section 4.2">4.2</a></li>
       <li>source
     list, <a href="#source-list" title="section 4.2">4.2</a></li>
       <li>sources, <a href="#dom-securitypolicysourcelistdirective-sources" title="section 6.1">6.1</a></li>
       <li>statusCode, <a href="#dom-securitypolicyviolationevent-statuscode" title="section 6.2">6.2</a></li>
       <li>stripped for reporting, <a href="#strip-uri-for-reporting" title="section 4.4">4.4</a></li>
       <li>strip uri for reporting, <a href="#strip-uri-for-reporting" title="section 4.4">4.4</a></li>
-      <li>style-src, <a href="#style_src" title="section 7.19">7.19</a></li>
+      <li>style-src, <a href="#style-src" title="section 7.19">7.19</a></li>
       <li>type, <a href="#dom-securitypolicyviolationevent-securitypolicyviolationeventtype-eventinitdict-type" title="section 6.2">6.2</a></li>
-      <li>uri-reference, <a href="#uri_reference" title="section 7.16">7.16</a></li>
+      <li>uri-reference, <a href="#uri-reference" title="section 7.16">7.16</a></li>
       <li>URL, <a href="#url" title="section 2.2">2.2</a></li>
       <li>url
         <ul>
@@ -6269,7 +6271,7 @@ Content-Security-Policy: style-src 'none'
           <li>dict-member for SecurityPolicyViolationEventInit, <a href="#dom-securitypolicyviolationeventinit-violateddirective" title="section 6.3">6.3</a></li>
         </ul>
       </li>
-      <li>wildcard-host, <a href="#wildcard_host" title="section 4.2">4.2</a></li>
+      <li>wildcard-host, <a href="#wildcard-host" title="section 4.2">4.2</a></li>
       <li>WSP, <a href="#wsp" title="section 2.4">2.4</a></li></ul>
     <h2 class="no-num heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
     <pre class="idl">partial interface <a class="idl-code" data-global-name="" data-link-type="interface" href="https://html.spec.whatwg.org/#htmlscriptelement">HTMLScriptElement</a> {

--- a/specs/content-security-policy/index.src.html
+++ b/specs/content-security-policy/index.src.html
@@ -971,9 +971,10 @@ type: interface
       <dfn>scheme-source</dfn>     = <a>scheme-part</a> ":"
       <dfn>host-source</dfn>       = [ <a>scheme-part</a> "://" ] <a>host-part</a> [ <a>port-part</a> ] [ <a>path-part</a> ]
       <dfn>keyword-source</dfn>    = "'self'" / "'unsafe-inline'" / "'unsafe-eval'" / "'unsafe-redirect'"
-      <dfn>base64-value</dfn>      = 1*( ALPHA / DIGIT / "+" / "/" / "-" / "_" )*2( "=" )
-      <dfn>nonce-value</dfn>       = <a>base64-value</a>
-      <dfn>hash-value</dfn>        = <a>base64-value</a>
+      <dfn>base64-value</dfn>      = 1*( ALPHA / DIGIT / "+" / "/" )*2( "=" )
+      <dfn>base64url-value</dfn>   = 1*( ALPHA / DIGIT / "-" / "_" )*2( "=" )
+      <dfn>nonce-value</dfn>       = <a>base64-value</a> / <a>base64url-value</a>
+      <dfn>hash-value</dfn>        = <a>base64-value</a> / <a>base64url-value</a>
       <dfn>nonce-source</dfn>      = "'nonce-" <a>nonce-value</a> "'"
       <dfn>hash-algo</dfn>         = "sha256" / "sha384" / "sha512"
       <dfn>hash-source</dfn>       = "'" <a>hash-algo</a> "-" <a>hash-value</a> "'"


### PR DESCRIPTION
As a follow up to w3c/webappsec#147 and 7b3b425ae340734a088323ff2ffb7f575d7e3163, I thought it might be nice to syntactically separate out base64 values and base64url values. @mikewest, what do you think?