### PR TITLE
Stylesheet links without a MIME type should be eligible for integrity checks

### DIFF
--- a/specs/subresourceintegrity/spec.markdown
+++ b/specs/subresourceintegrity/spec.markdown
@@ -631,7 +631,7 @@ failure, refuse to fetch the resource, and [report a violation][].
 ###### The `link` element for stylesheets
 
 Whenever a user agent attempts to [obtain a resource][] pointed to by a
-`link` element that has a `rel` attribute with the value of `stylesheet` and a type of `text/css`:
+`link` element that has a `rel` attribute with the value of `stylesheet`:
 
 1.  Set the [integrity metadata][] of the request to the value
     of the element's `integrity` attribute.


### PR DESCRIPTION
HTML allows stylesheets to be loaded without specifying a MIME type of text/css.

We should encourage developers to supply the MIME type but we should not require it before enforcing integrity checks on it.