### PR TITLE
Ignore trailing equal signs when comparing base64 hashes (fix #73)

### DIFF
--- a/specs/subresourceintegrity/spec.markdown
+++ b/specs/subresourceintegrity/spec.markdown
@@ -444,7 +444,7 @@ the user agent.
 6.  Let <var>algorithm</var> be the <var>alg</var> component of
     <var>metadata</var>.
 7.  Let <var>expectedValue</var> be the <var>val</var> component of
-    <var>metadata</var>.
+    <var>metadata</var> with any trailing U+003D EQUALS SIGN (`=`) removed.
 8.  Let <var>expectedType</var> be the value of <var>metadata</var>'s `ct`
     query string parameter.
 9.  If <var>expectedType</var> is not the empty string, and is not a


### PR DESCRIPTION
Both Firefox and Chrome ignore any trailing equal signs while
comparing the base64 hashes so we may as well make that explicit.

The reason why they both tolerate these extra trailing hashes is
that they don't actually compare the base64 strings, instead they
decode the the expected value and then compare the binary hashes
together.