### PR TITLE
Add francois as editor, remove Mike West

### DIFF
--- a/specs/subresourceintegrity/index.html
+++ b/specs/subresourceintegrity/index.html
@@ -24,9 +24,9 @@
         // only "name" is required
         editors:  [
             { name: "Frederik Braun", url: "mailto:fbraun@mozilla.com", company: "Mozilla Corporation", companyURL: "https://www.mozilla.com/" },
+            { name: "Francois Marier", url: "mailto:francois@mozilla.com", company: "Mozilla Corporation", companyURL: "https://www.mozilla.com/" },
             { name: "Devdatta Akhawe", url: "mailto:dev.akhawe@gmail.com", company: "UC Berkeley" },
             { name: "Joel Weinberger", url: "mailto:jww@google.com", company: "Google, Inc.", companyURL: "https://google.com/" },
-            { name: "Mike West", url: "mailto:mkwst@google.com", company: "Google, Inc.", companyURL: "https://google.com/" },
         ],
 
         // name of the WG
@@ -142,7 +142,7 @@ substitute malicious content.</p>
   <p>This example can be communicated to a user agent by adding the hash to a
 <code>script</code> element, like so:</p>
 
-  <pre><code>&lt;script src="https://code.jquery.com/jquery-1.10.2.min.js"
+  <pre class="example highlight"><code>&lt;script src="https://code.jquery.com/jquery-1.10.2.min.js"
         integrity="ni:///sha-256;C6CB9UYIS9UJeqinPHWTHVqh_E1uhG5Twh-Y5qFQmYg?ct=application/javascript"&gt;
 </code></pre>
 
@@ -202,7 +202,7 @@ can mitigate the risk that CDN compromise (or unexpectedly malicious
 behavior) would change her code in unfortunate ways by adding
 <a href="#dfn-integrity-metadata">integrity metadata</a> to the <code>script</code> element included on her page:</p>
 
-          <pre><code>&lt;script src="https://site53.cdn.net/include.js"
+          <pre class="example highlight"><code>&lt;script src="https://site53.cdn.net/include.js"
         integrity="ni:///sha-256;SDfwewFAE...wefjijfE?ct=application/javascript"&gt;&lt;/script&gt;
 </code></pre>
         </li>
@@ -213,7 +213,7 @@ the code she’s carefully reviewed is executed. She can do so by generating
 <a href="#dfn-integrity-metadata">integrity metadata</a> for the script she’s planning on including, and
 adding it to the <code>script</code> element she includes on her page:</p>
 
-          <pre><code>&lt;script src="https://analytics-r-us.com/v1.0/include.js"
+          <pre class="example highlight"><code>&lt;script src="https://analytics-r-us.com/v1.0/include.js"
         integrity="ni:///sha-256;SDfwewFAE...wefjijfE?ct=application/javascript"&gt;&lt;/script&gt;
 </code></pre>
         </li>
@@ -323,12 +323,12 @@ an author might choose <a href="#dfn-sha-2">SHA-256</a> as a hash function.
 <code>-MO_YqmqPm_BYZwlDkir51GTc9Pt9BvmLrXcRRma8u8</code> is the base64url-encoded
 digest that results. This can be encoded as an <code>ni</code> URI as follows:</p>
 
-    <pre><code>ni:///sha-256;-MO_YqmqPm_BYZwlDkir51GTc9Pt9BvmLrXcRRma8u8
+    <pre class="example highlight"><code>ni:///sha-256;-MO_YqmqPm_BYZwlDkir51GTc9Pt9BvmLrXcRRma8u8
 </code></pre>
 
     <p>Or, if the author further wishes to specify the Content Type (<code>text/plain</code>):</p>
 
-    <pre><code>ni:///sha-256;-MO_YqmqPm_BYZwlDkir51GTc9Pt9BvmLrXcRRma8u8?ct=text/plain
+    <pre class="example highlight"><code>ni:///sha-256;-MO_YqmqPm_BYZwlDkir51GTc9Pt9BvmLrXcRRma8u8?ct=text/plain
 </code></pre>
 
     <div class="note">
@@ -359,7 +359,7 @@ resource in order to provide agility in the face of future discoveries.
 For example, the “Hello, world.” resource described above may be described
 either of the following <code>ni</code> URLs:</p>
 
-      <pre><code>ni:///sha-256;-MO_YqmqPm_BYZwlDkir51GTc9Pt9BvmLrXcRRma8u8?ct=application/javascript
+      <pre class="example highlight"><code>ni:///sha-256;-MO_YqmqPm_BYZwlDkir51GTc9Pt9BvmLrXcRRma8u8?ct=application/javascript
 ni:///sha-512;rQw3wx1psxXzqB8TyM3nAQlK2RcluhsNwxmcqXE2YbgoDW735o8TPmIR4uWpoxUERddvFwjgRSGw7gNPCwuvJg?ct=application/javascript
 </code></pre>
 
@@ -900,7 +900,7 @@ logged into a particular service.</p>
     <p>Moreover, attackers can brute-force specific values in an otherwise
 static resource: consider a JSON response that looks like this:</p>
 
-    <pre><code>{'status': 'authenticated', 'username': 'Stephan Falken'}
+    <pre class="example highlight"><code>{'status': 'authenticated', 'username': 'Stephan Falken'}
 </code></pre>
 
     <p>An attacker can precompute hashes for the response with a variety of
@@ -923,6 +923,9 @@ will likely be difficult to avoid (image’s <code>naturalHeight</code> and
 
   <p>None of this is new. Much of the content here is inspired heavily by Gervase
 Markham’s <a href="http://www.gerv.net/security/link-fingerprints/">Link Fingerprints</a> concept, as well as WHATWG’s <a href="http://wiki.whatwg.org/wiki/Link_Hashes">Link Hashes</a>.</p>
+
+  <p>A special thanks to Mike West of Google, Inc. for his invaluable contributions
+to the initial version of this spec.</p>
 
 </section>
 

--- a/specs/subresourceintegrity/spec.markdown
+++ b/specs/subresourceintegrity/spec.markdown
@@ -772,6 +772,9 @@ will likely be difficult to avoid (image's `naturalHeight` and
 None of this is new. Much of the content here is inspired heavily by Gervase
 Markham's [Link Fingerprints][] concept, as well as WHATWG's [Link Hashes][].
 
+A special thanks to Mike West of Google, Inc. for his invaluable contributions
+to the initial version of this spec.
+
 [Link Fingerprints]: http://www.gerv.net/security/link-fingerprints/
 [Link Hashes]: http://wiki.whatwg.org/wiki/Link_Hashes
 </section>

--- a/specs/subresourceintegrity/template.erb
+++ b/specs/subresourceintegrity/template.erb
@@ -24,9 +24,9 @@
         // only "name" is required
         editors:  [
             { name: "Frederik Braun", url: "mailto:fbraun@mozilla.com", company: "Mozilla Corporation", companyURL: "https://www.mozilla.com/" },
+            { name: "Francois Marier", url: "mailto:francois@mozilla.com", company: "Mozilla Corporation", companyURL: "https://www.mozilla.com/" },
             { name: "Devdatta Akhawe", url: "mailto:dev.akhawe@gmail.com", company: "UC Berkeley" },
             { name: "Joel Weinberger", url: "mailto:jww@google.com", company: "Google, Inc.", companyURL: "https://google.com/" },
-            { name: "Mike West", url: "mailto:mkwst@google.com", company: "Google, Inc.", companyURL: "https://google.com/" },
         ],
 
         // name of the WG


### PR DESCRIPTION
As per our discussion on public-webappsec (https://lists.w3.org/Archives/Public/public-webappsec/2015Jan/0306.html) this patch adds Francois as an editor and removes Mike West (but adds him to the acknowledgements). @mozfreddyb @mikewest @devd, feel free to merge if you approve.