### PR TITLE
CSP2: remove base64url and sha-*

### DIFF
--- a/specs/CSP2/index.html
+++ b/specs/CSP2/index.html
@@ -1515,9 +1515,8 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
 <dfn data-dfn-type="dfn" data-noexport="" id="host_source">host-source<a class="self-link" href="#host_source"></a></dfn>       = [ <a data-link-type="dfn" href="#scheme_part">scheme-part</a> "://" ] <a data-link-type="dfn" href="#host_part">host-part</a> [ <a data-link-type="dfn" href="#port_part">port-part</a> ] [ <a data-link-type="dfn" href="#path_part">path-part</a> ]
 <dfn data-dfn-type="dfn" data-noexport="" id="keyword_source">keyword-source<a class="self-link" href="#keyword_source"></a></dfn>    = "'self'" / "'unsafe-inline'" / "'unsafe-eval'" / "'unsafe-redirect'"
 <dfn data-dfn-type="dfn" data-noexport="" id="base64_value">base64-value<a class="self-link" href="#base64_value"></a></dfn>      = 1*( ALPHA / DIGIT / "+" / "/" )*2( "=" )
-<dfn data-dfn-type="dfn" data-noexport="" id="base64url_value">base64url-value<a class="self-link" href="#base64url_value"></a></dfn>   = 1*( ALPHA / DIGIT / "-" / "_" )*2( "=" )
-<dfn data-dfn-type="dfn" data-noexport="" id="nonce_value">nonce-value<a class="self-link" href="#nonce_value"></a></dfn>       = <a data-link-type="dfn" href="#base64_value">base64-value</a> / <a data-link-type="dfn" href="#base64url_value">base64url-value</a>
-<dfn data-dfn-type="dfn" data-noexport="" id="hash_value">hash-value<a class="self-link" href="#hash_value"></a></dfn>        = <a data-link-type="dfn" href="#base64_value">base64-value</a> / <a data-link-type="dfn" href="#base64url_value">base64url-value</a>
+<dfn data-dfn-type="dfn" data-noexport="" id="nonce_value">nonce-value<a class="self-link" href="#nonce_value"></a></dfn>       = <a data-link-type="dfn" href="#base64_value">base64-value</a>
+<dfn data-dfn-type="dfn" data-noexport="" id="hash_value">hash-value<a class="self-link" href="#hash_value"></a></dfn>        = <a data-link-type="dfn" href="#base64_value">base64-value</a>
 <dfn data-dfn-type="dfn" data-noexport="" id="nonce_source">nonce-source<a class="self-link" href="#nonce_source"></a></dfn>      = "'nonce-" <a data-link-type="dfn" href="#nonce_value">nonce-value</a> "'"
 <dfn data-dfn-type="dfn" data-noexport="" id="hash_algo">hash-algo<a class="self-link" href="#hash_algo"></a></dfn>         = "sha256" / "sha384" / "sha512"
 <dfn data-dfn-type="dfn" data-noexport="" id="hash_source">hash-source<a class="self-link" href="#hash_source"></a></dfn>       = "'" <a data-link-type="dfn" href="#hash_algo">hash-algo</a> "-" <a data-link-type="dfn" href="#hash_value">hash-value</a> "'"
@@ -2279,19 +2278,19 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
                 
            <li><a data-link-type="dfn" href="#sha_256">SHA-256</a> if the <code><a data-link-type="dfn" href="#hash_algo">hash-algo</a></code>
                 component of <var>hash</var> is an <a data-link-type="dfn" href="http://www.w3.org/TR/html5/infrastructure.html#ascii-case-insensitive">ASCII case-insensitive
-                match</a> for the string "sha256" or "sha-256"
+                match</a> for the string "sha256"
            
 
                 
            <li><a data-link-type="dfn" href="#sha_384">SHA-384</a> if the <code><a data-link-type="dfn" href="#hash_algo">hash-algo</a></code>
                 component of <var>hash</var> is an <a data-link-type="dfn" href="http://www.w3.org/TR/html5/infrastructure.html#ascii-case-insensitive">ASCII case-insensitive
-                match</a> for the string "sha384" or "sha-384"
+                match</a> for the string "sha384"
            
 
                 
            <li><a data-link-type="dfn" href="#sha_512">SHA-512</a> if the <code><a data-link-type="dfn" href="#hash_algo">hash-algo</a></code>
                 component of <var>hash</var> is an <a data-link-type="dfn" href="http://www.w3.org/TR/html5/infrastructure.html#ascii-case-insensitive">ASCII case-insensitive
-                match</a> for the string "sha512" or "sha-512"
+                match</a> for the string "sha512"
            
               
           </ul>
@@ -2302,15 +2301,6 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
             
          <li>Let <var>expected</var> be the <code><a data-link-type="dfn" href="#hash_value">hash-value</a></code>
             component of <var>hash</var>.
-         
-
-            
-         <li>Normalize <var>expected</var> to
-            <a href="https://tools.ietf.org/html/rfc4648#section-4">base64
-            encoding</a> by replacing all U+002B PLUS SIGN (<code>+</code>)
-            characters with U+002D HYPHEN-MINUS (<code>-</code>) characters,
-            and all U+002F SOLIDUS (<code>/</code>) characters with U+005F LOW
-            LINE (<code>_</code>) characters.
          
 
             
@@ -4809,8 +4799,8 @@ alert("Allowed because nonce is valid.")
 
 
       <p>Usage is straightforward. The server computes the hash of a
-      particular script block’s contents, and includes the base64 or base64url
-      encoding of that value in the <code>Content-Security-Policy</code> header:</p>
+      particular script block’s contents, and includes the base64 encoding
+      of that value in the <code>Content-Security-Policy</code> header:</p>
       
 
       
@@ -5733,7 +5723,6 @@ Content-Security-Policy: style-src 'none'
    <li>ALPHA, <a href="#alpha">2.4</a>
    <li>ancestor-source, <a href="#ancestor_source">7.7</a>
    <li>ancestor-source-list, <a href="#ancestor_source_list">7.7</a>
-   <li>base64url-value, <a href="#base64url_value">4.2</a>
    <li>base64-value, <a href="#base64_value">4.2</a>
    <li>base-uri, <a href="#base_uri">7.1</a>
    <li>blockedURI

--- a/specs/CSP2/index.src.html
+++ b/specs/CSP2/index.src.html
@@ -988,10 +988,9 @@ type: method
       <dfn>scheme-source</dfn>     = <a>scheme-part</a> ":"
       <dfn>host-source</dfn>       = [ <a>scheme-part</a> "://" ] <a>host-part</a> [ <a>port-part</a> ] [ <a>path-part</a> ]
       <dfn>keyword-source</dfn>    = "'self'" / "'unsafe-inline'" / "'unsafe-eval'" / "'unsafe-redirect'"
-      <dfn>base64-value</dfn>      = 1*( ALPHA / DIGIT / "+" / "/" )*2( "=" )
-      <dfn>base64url-value</dfn>   = 1*( ALPHA / DIGIT / "-" / "_" )*2( "=" )
-      <dfn>nonce-value</dfn>       = <a>base64-value</a> / <a>base64url-value</a>
-      <dfn>hash-value</dfn>        = <a>base64-value</a> / <a>base64url-value</a>
+      <dfn>base64-value</dfn>      = 1*( ALPHA / DIGIT / "+" / "/" / "-" / "_" )*2( "=" )
+      <dfn>nonce-value</dfn>       = <a>base64-value</a>
+      <dfn>hash-value</dfn>        = <a>base64-value</a>
       <dfn>nonce-source</dfn>      = "'nonce-" <a>nonce-value</a> "'"
       <dfn>hash-algo</dfn>         = "sha256" / "sha384" / "sha512"
       <dfn>hash-source</dfn>       = "'" <a>hash-algo</a> "-" <a>hash-value</a> "'"

--- a/specs/CSP2/index.src.html
+++ b/specs/CSP2/index.src.html
@@ -988,7 +988,7 @@ type: method
       <dfn>scheme-source</dfn>     = <a>scheme-part</a> ":"
       <dfn>host-source</dfn>       = [ <a>scheme-part</a> "://" ] <a>host-part</a> [ <a>port-part</a> ] [ <a>path-part</a> ]
       <dfn>keyword-source</dfn>    = "'self'" / "'unsafe-inline'" / "'unsafe-eval'" / "'unsafe-redirect'"
-      <dfn>base64-value</dfn>      = 1*( ALPHA / DIGIT / "+" / "/" / "-" / "_" )*2( "=" )
+      <dfn>base64-value</dfn>      = 1*( ALPHA / DIGIT / "+" / "/" )*2( "=" )
       <dfn>nonce-value</dfn>       = <a>base64-value</a>
       <dfn>hash-value</dfn>        = <a>base64-value</a>
       <dfn>nonce-source</dfn>      = "'nonce-" <a>nonce-value</a> "'"
@@ -1494,27 +1494,20 @@ type: method
               <ul>
                 <li><a>SHA-256</a> if the <code><a>hash-algo</a></code>
                 component of <var>hash</var> is an <a>ASCII case-insensitive
-                match</a> for the string "sha256" or "sha-256"</li>
+                match</a> for the string "sha256"</li>
 
                 <li><a>SHA-384</a> if the <code><a>hash-algo</a></code>
                 component of <var>hash</var> is an <a>ASCII case-insensitive
-                match</a> for the string "sha384" or "sha-384"</li>
+                match</a> for the string "sha384"</li>
 
                 <li><a>SHA-512</a> if the <code><a>hash-algo</a></code>
                 component of <var>hash</var> is an <a>ASCII case-insensitive
-                match</a> for the string "sha512" or "sha-512"</li>
+                match</a> for the string "sha512"</li>
               </ul>
             </li>
 
             <li>Let <var>expected</var> be the <code><a>hash-value</a></code>
             component of <var>hash</var>.</li>
-
-            <li>Normalize <var>expected</var> to
-            <a href="https://tools.ietf.org/html/rfc4648#section-4">base64
-            encoding</a> by replacing all U+002B PLUS SIGN (<code>+</code>)
-            characters with U+002D HYPHEN-MINUS (<code>-</code>) characters,
-            and all U+002F SOLIDUS (<code>/</code>) characters with U+005F LOW
-            LINE (<code>_</code>) characters.</li>
 
             <li>Let <var>actual</var> be the
             <a href="https://tools.ietf.org/html/rfc4648#section-4">base64
@@ -3257,8 +3250,8 @@ type: method
       of script.
 
       Usage is straightforward. The server computes the hash of a
-      particular script block's contents, and includes the base64 or base64url
-      encoding of that value in the <code>Content-Security-Policy</code> header:
+      particular script block's contents, and includes the base64 encoding
+      of that value in the <code>Content-Security-Policy</code> header:
 
       <pre>
         Content-Security-Policy: <a>default-src</a> 'self';

--- a/specs/CSP2/published/2015-01-CR.html
+++ b/specs/CSP2/published/2015-01-CR.html
@@ -1487,9 +1487,8 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
 <dfn data-dfn-type="dfn" data-noexport="" id="host_source">host-source<a class="self-link" href="#host_source"></a></dfn>       = [ <a data-link-type="dfn" href="#scheme_part">scheme-part</a> "://" ] <a data-link-type="dfn" href="#host_part">host-part</a> [ <a data-link-type="dfn" href="#port_part">port-part</a> ] [ <a data-link-type="dfn" href="#path_part">path-part</a> ]
 <dfn data-dfn-type="dfn" data-noexport="" id="keyword_source">keyword-source<a class="self-link" href="#keyword_source"></a></dfn>    = "'self'" / "'unsafe-inline'" / "'unsafe-eval'" / "'unsafe-redirect'"
 <dfn data-dfn-type="dfn" data-noexport="" id="base64_value">base64-value<a class="self-link" href="#base64_value"></a></dfn>      = 1*( ALPHA / DIGIT / "+" / "/" )*2( "=" )
-<dfn data-dfn-type="dfn" data-noexport="" id="base64url_value">base64url-value<a class="self-link" href="#base64url_value"></a></dfn>   = 1*( ALPHA / DIGIT / "-" / "_" )*2( "=" )
-<dfn data-dfn-type="dfn" data-noexport="" id="nonce_value">nonce-value<a class="self-link" href="#nonce_value"></a></dfn>       = <a data-link-type="dfn" href="#base64_value">base64-value</a> / <a data-link-type="dfn" href="#base64url_value">base64url-value</a>
-<dfn data-dfn-type="dfn" data-noexport="" id="hash_value">hash-value<a class="self-link" href="#hash_value"></a></dfn>        = <a data-link-type="dfn" href="#base64_value">base64-value</a> / <a data-link-type="dfn" href="#base64url_value">base64url-value</a>
+<dfn data-dfn-type="dfn" data-noexport="" id="nonce_value">nonce-value<a class="self-link" href="#nonce_value"></a></dfn>       = <a data-link-type="dfn" href="#base64_value">base64-value</a>
+<dfn data-dfn-type="dfn" data-noexport="" id="hash_value">hash-value<a class="self-link" href="#hash_value"></a></dfn>        = <a data-link-type="dfn" href="#base64_value">base64-value</a>
 <dfn data-dfn-type="dfn" data-noexport="" id="nonce_source">nonce-source<a class="self-link" href="#nonce_source"></a></dfn>      = "'nonce-" <a data-link-type="dfn" href="#nonce_value">nonce-value</a> "'"
 <dfn data-dfn-type="dfn" data-noexport="" id="hash_algo">hash-algo<a class="self-link" href="#hash_algo"></a></dfn>         = "sha256" / "sha384" / "sha512"
 <dfn data-dfn-type="dfn" data-noexport="" id="hash_source">hash-source<a class="self-link" href="#hash_source"></a></dfn>       = "'" <a data-link-type="dfn" href="#hash_algo">hash-algo</a> "-" <a data-link-type="dfn" href="#hash_value">hash-value</a> "'"
@@ -2251,19 +2250,19 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
                 
            <li><a data-link-type="dfn" href="#sha_256">SHA-256</a> if the <code><a data-link-type="dfn" href="#hash_algo">hash-algo</a></code>
                 component of <var>hash</var> is an <a data-link-type="dfn" href="http://www.w3.org/TR/html5/infrastructure.html#ascii-case-insensitive">ASCII case-insensitive
-                match</a> for the string "sha256" or "sha-256"
+                match</a> for the string "sha256"
            
 
                 
            <li><a data-link-type="dfn" href="#sha_384">SHA-384</a> if the <code><a data-link-type="dfn" href="#hash_algo">hash-algo</a></code>
                 component of <var>hash</var> is an <a data-link-type="dfn" href="http://www.w3.org/TR/html5/infrastructure.html#ascii-case-insensitive">ASCII case-insensitive
-                match</a> for the string "sha384" or "sha-384"
+                match</a> for the string "sha384"
            
 
                 
            <li><a data-link-type="dfn" href="#sha_512">SHA-512</a> if the <code><a data-link-type="dfn" href="#hash_algo">hash-algo</a></code>
                 component of <var>hash</var> is an <a data-link-type="dfn" href="http://www.w3.org/TR/html5/infrastructure.html#ascii-case-insensitive">ASCII case-insensitive
-                match</a> for the string "sha512" or "sha-512"
+                match</a> for the string "sha512"
            
               
           </ul>
@@ -2274,15 +2273,6 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
             
          <li>Let <var>expected</var> be the <code><a data-link-type="dfn" href="#hash_value">hash-value</a></code>
             component of <var>hash</var>.
-         
-
-            
-         <li>Normalize <var>expected</var> to
-            <a href="https://tools.ietf.org/html/rfc4648#section-4">base64
-            encoding</a> by replacing all U+002B PLUS SIGN (<code>+</code>)
-            characters with U+002D HYPHEN-MINUS (<code>-</code>) characters,
-            and all U+002F SOLIDUS (<code>/</code>) characters with U+005F LOW
-            LINE (<code>_</code>) characters.
          
 
             
@@ -4781,8 +4771,8 @@ alert("Allowed because nonce is valid.")
 
 
       <p>Usage is straightforward. The server computes the hash of a
-      particular script block’s contents, and includes the base64 or base64url
-      encoding of that value in the <code>Content-Security-Policy</code> header:</p>
+      particular script block’s contents, and includes the base64 encoding
+      of that value in the <code>Content-Security-Policy</code> header:</p>
       
 
       
@@ -5705,7 +5695,6 @@ Content-Security-Policy: style-src 'none'
    <li>ALPHA, <a href="#alpha">2.4</a>
    <li>ancestor-source, <a href="#ancestor_source">7.7</a>
    <li>ancestor-source-list, <a href="#ancestor_source_list">7.7</a>
-   <li>base64url-value, <a href="#base64url_value">4.2</a>
    <li>base64-value, <a href="#base64_value">4.2</a>
    <li>base-uri, <a href="#base_uri">7.1</a>
    <li>blockedURI

--- a/specs/content-security-policy/index.html
+++ b/specs/content-security-policy/index.html
@@ -1559,9 +1559,8 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
 <dfn data-dfn-type="dfn" data-noexport="" id="host_source">host-source<a class="self-link" href="#host_source"></a></dfn>       = [ <a data-link-type="dfn" href="#scheme_part">scheme-part</a> "://" ] <a data-link-type="dfn" href="#host_part">host-part</a> [ <a data-link-type="dfn" href="#port_part">port-part</a> ] [ <a data-link-type="dfn" href="#path_part">path-part</a> ]
 <dfn data-dfn-type="dfn" data-noexport="" id="keyword_source">keyword-source<a class="self-link" href="#keyword_source"></a></dfn>    = "'self'" / "'unsafe-inline'" / "'unsafe-eval'" / "'unsafe-redirect'"
 <dfn data-dfn-type="dfn" data-noexport="" id="base64_value">base64-value<a class="self-link" href="#base64_value"></a></dfn>      = 1*( ALPHA / DIGIT / "+" / "/" )*2( "=" )
-<dfn data-dfn-type="dfn" data-noexport="" id="base64url_value">base64url-value<a class="self-link" href="#base64url_value"></a></dfn>   = 1*( ALPHA / DIGIT / "-" / "_" )*2( "=" )
-<dfn data-dfn-type="dfn" data-noexport="" id="nonce_value">nonce-value<a class="self-link" href="#nonce_value"></a></dfn>       = <a data-link-type="dfn" href="#base64_value">base64-value</a> / <a data-link-type="dfn" href="#base64url_value">base64url-value</a>
-<dfn data-dfn-type="dfn" data-noexport="" id="hash_value">hash-value<a class="self-link" href="#hash_value"></a></dfn>        = <a data-link-type="dfn" href="#base64_value">base64-value</a> / <a data-link-type="dfn" href="#base64url_value">base64url-value</a>
+<dfn data-dfn-type="dfn" data-noexport="" id="nonce_value">nonce-value<a class="self-link" href="#nonce_value"></a></dfn>       = <a data-link-type="dfn" href="#base64_value">base64-value</a>
+<dfn data-dfn-type="dfn" data-noexport="" id="hash_value">hash-value<a class="self-link" href="#hash_value"></a></dfn>        = <a data-link-type="dfn" href="#base64_value">base64-value</a>
 <dfn data-dfn-type="dfn" data-noexport="" id="nonce_source">nonce-source<a class="self-link" href="#nonce_source"></a></dfn>      = "'nonce-" <a data-link-type="dfn" href="#nonce_value">nonce-value</a> "'"
 <dfn data-dfn-type="dfn" data-noexport="" id="hash_algo">hash-algo<a class="self-link" href="#hash_algo"></a></dfn>         = "sha256" / "sha384" / "sha512"
 <dfn data-dfn-type="dfn" data-noexport="" id="hash_source">hash-source<a class="self-link" href="#hash_source"></a></dfn>       = "'" <a data-link-type="dfn" href="#hash_algo">hash-algo</a> "-" <a data-link-type="dfn" href="#hash_value">hash-value</a> "'"
@@ -2328,19 +2327,19 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
                 
            <li><a data-link-type="dfn" href="#sha_256">SHA-256</a> if the <code><a data-link-type="dfn" href="#hash_algo">hash-algo</a></code>
                 component of <var>hash</var> is an <a data-link-type="dfn" href="http://www.w3.org/TR/html5/infrastructure.html#ascii-case-insensitive">ASCII case-insensitive
-                match</a> for the string "sha256" or "sha-256"
+                match</a> for the string "sha256"
            
 
                 
            <li><a data-link-type="dfn" href="#sha_384">SHA-384</a> if the <code><a data-link-type="dfn" href="#hash_algo">hash-algo</a></code>
                 component of <var>hash</var> is an <a data-link-type="dfn" href="http://www.w3.org/TR/html5/infrastructure.html#ascii-case-insensitive">ASCII case-insensitive
-                match</a> for the string "sha384" or "sha-384"
+                match</a> for the string "sha384"
            
 
                 
            <li><a data-link-type="dfn" href="#sha_512">SHA-512</a> if the <code><a data-link-type="dfn" href="#hash_algo">hash-algo</a></code>
                 component of <var>hash</var> is an <a data-link-type="dfn" href="http://www.w3.org/TR/html5/infrastructure.html#ascii-case-insensitive">ASCII case-insensitive
-                match</a> for the string "sha512" or "sha-512"
+                match</a> for the string "sha512"
            
               
           </ul>
@@ -2351,15 +2350,6 @@ Content-Security-Policy: <a data-link-type="dfn" href="#connect_src">connect-src
             
          <li>Let <var>expected</var> be the <code><a data-link-type="dfn" href="#hash_value">hash-value</a></code>
             component of <var>hash</var>.
-         
-
-            
-         <li>Normalize <var>expected</var> to
-            <a href="https://tools.ietf.org/html/rfc4648#section-4">base64
-            encoding</a> by replacing all U+002B PLUS SIGN (<code>+</code>)
-            characters with U+002D HYPHEN-MINUS (<code>-</code>) characters,
-            and all U+002F SOLIDUS (<code>/</code>) characters with U+005F LOW
-            LINE (<code>_</code>) characters.
          
 
             
@@ -5035,8 +5025,8 @@ alert("Allowed because nonce is valid.")
 
 
       <p>Usage is straightforward. The server computes the hash of a
-      particular script block’s contents, and includes the base64 or base64url
-      encoding of that value in the <code>Content-Security-Policy</code> header:</p>
+      particular script block’s contents, and includes the base64 encoding
+      of that value in the <code>Content-Security-Policy</code> header:</p>
       
 
       
@@ -5969,7 +5959,6 @@ Content-Security-Policy: style-src 'none'
    <li>ALPHA, <a href="#alpha">2.4</a>
    <li>ancestor-source, <a href="#ancestor_source">7.7</a>
    <li>ancestor-source-list, <a href="#ancestor_source_list">7.7</a>
-   <li>base64url-value, <a href="#base64url_value">4.2</a>
    <li>base64-value, <a href="#base64_value">4.2</a>
    <li>base-uri, <a href="#base_uri">7.1</a>
    <li>blockedURL

--- a/specs/content-security-policy/index.src.html
+++ b/specs/content-security-policy/index.src.html
@@ -1013,10 +1013,9 @@ type: method
       <dfn>scheme-source</dfn>     = <a>scheme-part</a> ":"
       <dfn>host-source</dfn>       = [ <a>scheme-part</a> "://" ] <a>host-part</a> [ <a>port-part</a> ] [ <a>path-part</a> ]
       <dfn>keyword-source</dfn>    = "'self'" / "'unsafe-inline'" / "'unsafe-eval'" / "'unsafe-redirect'"
-      <dfn>base64-value</dfn>      = 1*( ALPHA / DIGIT / "+" / "/" )*2( "=" )
-      <dfn>base64url-value</dfn>   = 1*( ALPHA / DIGIT / "-" / "_" )*2( "=" )
-      <dfn>nonce-value</dfn>       = <a>base64-value</a> / <a>base64url-value</a>
-      <dfn>hash-value</dfn>        = <a>base64-value</a> / <a>base64url-value</a>
+      <dfn>base64-value</dfn>      = 1*( ALPHA / DIGIT / "+" / "/" / "-" / "_" )*2( "=" )
+      <dfn>nonce-value</dfn>       = <a>base64-value</a>
+      <dfn>hash-value</dfn>        = <a>base64-value</a>
       <dfn>nonce-source</dfn>      = "'nonce-" <a>nonce-value</a> "'"
       <dfn>hash-algo</dfn>         = "sha256" / "sha384" / "sha512"
       <dfn>hash-source</dfn>       = "'" <a>hash-algo</a> "-" <a>hash-value</a> "'"

--- a/specs/content-security-policy/index.src.html
+++ b/specs/content-security-policy/index.src.html
@@ -1013,7 +1013,7 @@ type: method
       <dfn>scheme-source</dfn>     = <a>scheme-part</a> ":"
       <dfn>host-source</dfn>       = [ <a>scheme-part</a> "://" ] <a>host-part</a> [ <a>port-part</a> ] [ <a>path-part</a> ]
       <dfn>keyword-source</dfn>    = "'self'" / "'unsafe-inline'" / "'unsafe-eval'" / "'unsafe-redirect'"
-      <dfn>base64-value</dfn>      = 1*( ALPHA / DIGIT / "+" / "/" / "-" / "_" )*2( "=" )
+      <dfn>base64-value</dfn>      = 1*( ALPHA / DIGIT / "+" / "/" )*2( "=" )
       <dfn>nonce-value</dfn>       = <a>base64-value</a>
       <dfn>hash-value</dfn>        = <a>base64-value</a>
       <dfn>nonce-source</dfn>      = "'nonce-" <a>nonce-value</a> "'"
@@ -1524,27 +1524,20 @@ type: method
               <ul>
                 <li><a>SHA-256</a> if the <code><a>hash-algo</a></code>
                 component of <var>hash</var> is an <a>ASCII case-insensitive
-                match</a> for the string "sha256" or "sha-256"</li>
+                match</a> for the string "sha256"</li>
 
                 <li><a>SHA-384</a> if the <code><a>hash-algo</a></code>
                 component of <var>hash</var> is an <a>ASCII case-insensitive
-                match</a> for the string "sha384" or "sha-384"</li>
+                match</a> for the string "sha384"</li>
 
                 <li><a>SHA-512</a> if the <code><a>hash-algo</a></code>
                 component of <var>hash</var> is an <a>ASCII case-insensitive
-                match</a> for the string "sha512" or "sha-512"</li>
+                match</a> for the string "sha512"</li>
               </ul>
             </li>
 
             <li>Let <var>expected</var> be the <code><a>hash-value</a></code>
             component of <var>hash</var>.</li>
-
-            <li>Normalize <var>expected</var> to
-            <a href="https://tools.ietf.org/html/rfc4648#section-4">base64
-            encoding</a> by replacing all U+002B PLUS SIGN (<code>+</code>)
-            characters with U+002D HYPHEN-MINUS (<code>-</code>) characters,
-            and all U+002F SOLIDUS (<code>/</code>) characters with U+005F LOW
-            LINE (<code>_</code>) characters.</li>
 
             <li>Let <var>actual</var> be the
             <a href="https://tools.ietf.org/html/rfc4648#section-4">base64
@@ -3447,8 +3440,8 @@ type: method
       of script.
 
       Usage is straightforward. The server computes the hash of a
-      particular script block's contents, and includes the base64 or base64url
-      encoding of that value in the <code>Content-Security-Policy</code> header:
+      particular script block's contents, and includes the base64 encoding
+      of that value in the <code>Content-Security-Policy</code> header:
 
       <pre>
         Content-Security-Policy: <a>default-src</a> 'self';


### PR DESCRIPTION
As per https://lists.w3.org/Archives/Public/public-webappsec/2015Feb/0153.html, I have reverted the changes that were made to bring CSP in line with the SRI spec.