### PR TITLE
Add a new "referrer attribute" delivery mechanism

### DIFF
--- a/specs/referrer-policy/index.html
+++ b/specs/referrer-policy/index.html
@@ -71,7 +71,7 @@
    <h1 class="p-name no-ref" id="title">Referrer Policy</h1>
   
    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft,
-    <time class="dt-updated" datetime="2015-02-10">10 February 2015</time></span></h2>
+    <time class="dt-updated" datetime="2015-02-15">15 February 2015</time></span></h2>
   
    <div data-fill-with="spec-metadata">
     <dl>
@@ -83,6 +83,8 @@
      <dd><a href="https://github.com/w3c/webappsec/commits/master/specs/referrer-policy/index.src.html">https://github.com/w3c/webappsec/commits/master/specs/referrer-policy/index.src.html</a>
      <dt>Feedback:
      <dd><span><a href="mailto:public-webappsec@w3.org?subject=%5BREFERRER%5D%20feedback">public-webappsec@w3.org</a> with subject line “<kbd>[REFERRER] <var>… message topic …</var></kbd>” (<a href="http://lists.w3.org/Archives/Public/public-webappsec/" rel="discussion">archives</a>)</span>
+     <dt>Issue Tracking:
+     <dd><a href="#issues-index">Inline In Spec</a>
      <dt class="editor">Editors:
      <dd class="editor">
       <div class="p-author h-card vcard"><a class="p-name fn u-email email" href="mailto:eisinger@google.com">Jochen Eisinger</a> (<span class="p-org org">Google Inc.</span>)</div>
@@ -193,12 +195,14 @@
         <li><a href="#referrer-usage"><span class="secno">4.1.1</span> <span class="content">Usage</span></a>
        </ul>
       <li><a href="#referrer-policy-delivery-meta"><span class="secno">4.2</span> <span class="content">Delivery via <span data-lt="meta">meta</span></span></a>
-      <li><a href="#referrer-policy-delivery-implicit"><span class="secno">4.3</span> <span class="content">Implicit Delivery</span></a>
+      <li><a href="#referrer-policy-delivery-referrer-attribute"><span class="secno">4.3</span> <span class="content">Delivery
+  via a <code>referrer</code> attribute</span></a>
+      <li><a href="#referrer-policy-delivery-implicit"><span class="secno">4.4</span> <span class="content">Implicit Delivery</span></a>
        <ul class="toc">
-        <li><a href="#referrer-policy-delivery-implicit-nested"><span class="secno">4.3.1</span> <span class="content">
+        <li><a href="#referrer-policy-delivery-implicit-nested"><span class="secno">4.4.1</span> <span class="content">
      Nested Browsing Contexts
   </span></a>
-        <li><a href="#referrer-policy-delivery-implicit-workers"><span class="secno">4.3.2</span> <span class="content">
+        <li><a href="#referrer-policy-delivery-implicit-workers"><span class="secno">4.4.2</span> <span class="content">
     Workers
   </span></a>
        </ul>
@@ -236,6 +240,7 @@
       <li><a href="#informative"><span class="secno"></span> <span class="content">Informative References</span></a>
      </ul>
     <li><a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
+    <li><a href="#issues-index"><span class="secno"></span> <span class="content">Issues Index</span></a>
    </ul></div>
 
   <main>
@@ -750,6 +755,12 @@
      
     
      <li>
+      Via a <code>referrer</code> attribute on an <code><a data-link-type="element" href="https://html.spec.whatwg.org/#the-a-element">a</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/#the-area-element">area</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/#the-img-element">img</a></code>
+      or <code><a data-link-type="element" href="https://html.spec.whatwg.org/#the-iframe-element">iframe</a></code> element.
+    
+     
+    
+     <li>
       Implicitly, via inheritance.
     
      
@@ -961,14 +972,72 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
     </dl>
 
   
-    <h3 class="heading settled" data-level="4.3" id="referrer-policy-delivery-implicit"><span class="secno">4.3. </span><span class="content">Implicit Delivery</span><a class="self-link" href="#referrer-policy-delivery-implicit"></a></h3>
+    <h3 class="heading settled" data-level="4.3" id="referrer-policy-delivery-referrer-attribute"><span class="secno">4.3. </span><span class="content">Delivery
+  via a <code>referrer</code> attribute</span><a class="self-link" href="#referrer-policy-delivery-referrer-attribute"></a></h3>
+
+
+    <p>A referrer policy may be set when a <code>referrer</code> attribute is
+  added to an <code><a data-link-type="element" href="https://html.spec.whatwg.org/#the-a-element">a</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/#the-area-element">area</a></code>,
+  <code><a data-link-type="element" href="https://html.spec.whatwg.org/#the-img-element">img</a></code> or <code><a data-link-type="element" href="https://html.spec.whatwg.org/#the-iframe-element">iframe</a></code>
+  element, for example:</p>
+
+  
+    <pre class="example">&lt;a href="http://example.com" referrer="origin">
+</pre>
+
+
+    <p>The following values for the <code>referrer</code> attribute are valid,
+  and map to the listed <a data-link-type="dfn" href="#referrer-policy">referrer policy</a> values:</p>
+
+  
+    <dl>
+    
+     <dt>no-referrer
+     
+    
+     <dd><a data-link-type="dfn" href="#no-referrer"><code>No Referrer</code></a>
+     
+    
+     <dt>origin
+     
+    
+     <dd><a data-link-type="dfn" href="#origin"><code>Origin</code></a>
+     
+    
+     <dt>unsafe-url
+     
+    
+     <dd><a data-link-type="dfn" href="#unsafe-url"><code>Unsafe URL</code></a>
+     
+  
+    </dl>
+
+
+    <p>A policy delivered via a <code>referrer</code> attribute on an element
+  takes precedence over the policy defined for the whole document via CSP or
+  a <a data-link-type="element" href="https://html.spec.whatwg.org/#meta">meta</a> element.</p>
+
+
+    <p class="issue" id="issue-4ec1eba2"><a class="self-link" href="#issue-4ec1eba2"></a>If an <code><a data-link-type="element" href="https://html.spec.whatwg.org/#the-a-element">a</a></code>
+  or <code><a data-link-type="element" href="https://html.spec.whatwg.org/#the-area-element">area</a></code> element includes both
+  a <code>referrer</code> attribute as well as
+  a <a href="https://html.spec.whatwg.org/#link-type-noreferrer"><code>noreferrer</code>
+  link type</a>, should the policy of the <code>referrer</code> attribute
+  take precedence over the link type, as suggested
+  by <a href="https://lists.w3.org/Archives/Public/public-webappsec/2015Feb/0235.html">Martin
+  Thomson</a>, or should we take the more conservative approach as suggested
+  by <a href="https://lists.w3.org/Archives/Public/public-webappsec/2015Feb/0283.html">Brian
+  Smith</a> and honor the <code>noreferrer</code> link type?</p>
+
+  
+    <h3 class="heading settled" data-level="4.4" id="referrer-policy-delivery-implicit"><span class="secno">4.4. </span><span class="content">Implicit Delivery</span><a class="self-link" href="#referrer-policy-delivery-implicit"></a></h3>
 
 
     <p>A <a data-link-type="dfn" href="#javascript-global-environment">global environment</a> inherits the <a data-link-type="dfn" href="#referrer-policy">referrer policy</a> of another
   environment in several circumstances:</p>
 
   
-    <h4 class="heading settled" data-level="4.3.1" id="referrer-policy-delivery-implicit-nested"><span class="secno">4.3.1. </span><span class="content">
+    <h4 class="heading settled" data-level="4.4.1" id="referrer-policy-delivery-implicit-nested"><span class="secno">4.4.1. </span><span class="content">
      Nested Browsing Contexts
   </span><a class="self-link" href="#referrer-policy-delivery-implicit-nested"></a></h4>
 
@@ -1005,7 +1074,7 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
     </ol>
 
   
-    <h4 class="heading settled" data-level="4.3.2" id="referrer-policy-delivery-implicit-workers"><span class="secno">4.3.2. </span><span class="content">
+    <h4 class="heading settled" data-level="4.4.2" id="referrer-policy-delivery-implicit-workers"><span class="secno">4.4.2. </span><span class="content">
     Workers
   </span><a class="self-link" href="#referrer-policy-delivery-implicit-workers"></a></h4>
 
@@ -1106,6 +1175,10 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
   <code><a data-link-type="dfn" href="#noreferrer">noreferrer</a></code>, then <var>request</var>’s
   <code>referrer</code> will be <code>no referrer</code>, and Fetch won’t call
   into this algorithm.</p>
+
+
+    <p class="issue" id="issue-2cf94c0c"><a class="self-link" href="#issue-2cf94c0c"></a>This algorithm needs to be modifed to take into account any local
+  overrides via the referrer attribute on elements.</p>
 
   
     <ol>
@@ -1561,7 +1634,7 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
    <dt id="biblio-rfc7231"><a class="self-link" href="#biblio-rfc7231"></a>[RFC7231]
    <dd>Roy T. Fielding; Julian F. Reschke. <a href="http://www.ietf.org/rfc/rfc7231.txt">HTTP/1.1 Semantics and Content</a>. RFC. URL: <a href="http://www.ietf.org/rfc/rfc7231.txt">http://www.ietf.org/rfc/rfc7231.txt</a>
    <dt id="biblio-url"><a class="self-link" href="#biblio-url"></a>[URL]
-   <dd>Anne van Kesteren. <a href="http://url.spec.whatwg.org/">URL</a>. Living Standard. URL: <a href="http://url.spec.whatwg.org/">http://url.spec.whatwg.org/</a>
+   <dd>Anne van Kesteren. <a href="https://url.spec.whatwg.org/">URL</a>. Living Standard. URL: <a href="https://url.spec.whatwg.org/">https://url.spec.whatwg.org/</a>
    <dt id="biblio-html5"><a class="self-link" href="#biblio-html5"></a>[html5]
    <dd>Robin Berjon; et al. <a href="http://www.w3.org/TR/html5/">HTML5</a>. 28 October 2014. REC. URL: <a href="http://www.w3.org/TR/html5/">http://www.w3.org/TR/html5/</a>
    <dt id="biblio-rfc2119"><a class="self-link" href="#biblio-rfc2119"></a>[rfc2119]
@@ -1614,5 +1687,19 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
    <li>same-origin request, <a href="#same_origin-request">2.2</a>
    <li>TLS-protected, <a href="#tls_protected">2.2</a>
    <li>Unsafe URL, <a href="#unsafe-url">3.5</a>
-   <li>worker environment, <a href="#worker-environment">2.2</a></ul></body>
+   <li>worker environment, <a href="#worker-environment">2.2</a></ul>
+  <h2 class="no-num heading settled" id="issues-index"><span class="content">Issues Index</span><a class="self-link" href="#issues-index"></a></h2>
+  <div style="counter-reset:issue">
+   <div class="issue">If an <code><a data-link-type="element" href="https://html.spec.whatwg.org/#the-a-element">a</a></code>
+  or <code><a data-link-type="element" href="https://html.spec.whatwg.org/#the-area-element">area</a></code> element includes both
+  a <code>referrer</code> attribute as well as
+  a <a href="https://html.spec.whatwg.org/#link-type-noreferrer"><code>noreferrer</code>
+  link type</a>, should the policy of the <code>referrer</code> attribute
+  take precedence over the link type, as suggested
+  by <a href="https://lists.w3.org/Archives/Public/public-webappsec/2015Feb/0235.html">Martin
+  Thomson</a>, or should we take the more conservative approach as suggested
+  by <a href="https://lists.w3.org/Archives/Public/public-webappsec/2015Feb/0283.html">Brian
+  Smith</a> and honor the <code>noreferrer</code> link type?<a href="#issue-4ec1eba2"> ↵ </a></div>
+   <div class="issue">This algorithm needs to be modifed to take into account any local
+  overrides via the referrer attribute on elements.<a href="#issue-2cf94c0c"> ↵ </a></div></div></body>
 </html>

--- a/specs/referrer-policy/index.src.html
+++ b/specs/referrer-policy/index.src.html
@@ -451,7 +451,8 @@ urlPrefix: http://www.w3.org/TR/html5/
       Via a <{meta}> element with a <{meta/name}> of <code>referrer</code>.
     </li>
     <li>
-      Via a <code>referrer</code> attribute on an <{a}> or <{area}> element.
+      Via a <code>referrer</code> attribute on an <{a}>, <{area}>, <{img}>
+      or <{iframe}> element.
     </li>
     <li>
       Implicitly, via inheritance.
@@ -590,7 +591,8 @@ urlPrefix: http://www.w3.org/TR/html5/
   via a <code>referrer</code> attribute</h3>
 
   A referrer policy may be set when a <code>referrer</code> attribute is
-  added to an <code><a element>a</a></code> or <code><a element>area</a></code>
+  added to an <code><a element>a</a></code>, <code><a element>area</a></code>,
+  <code><a element>img</a></code> or <code><a element>iframe</a></code>
   element, for example:
 
   <pre class="example">

--- a/specs/referrer-policy/index.src.html
+++ b/specs/referrer-policy/index.src.html
@@ -619,6 +619,17 @@ urlPrefix: http://www.w3.org/TR/html5/
   takes precedence over the policy defined for the whole document via CSP or
   a <a element>meta</a> element.
 
+  ISSUE: If an <code><a element>a</a></code>
+  or <code><a element>area</a></code> element includes both
+  a <code>referrer</code> attribute as well as
+  a <a href="https://html.spec.whatwg.org/#link-type-noreferrer"><code>noreferrer</code>
+  link type</a>, should the policy of the <code>referrer</code> attribute
+  take precedence over the link type, as suggested
+  by <a href="https://lists.w3.org/Archives/Public/public-webappsec/2015Feb/0235.html">Martin
+  Thomson</a>, or should we take the more conservative approach as suggested
+  by <a href="https://lists.w3.org/Archives/Public/public-webappsec/2015Feb/0283.html">Brian
+  Smith</a> and honor the <code>noreferrer</code> link type?
+
   <h3 id="referrer-policy-delivery-implicit">Implicit Delivery</h3>
 
   A <a>global environment</a> inherits the <a>referrer policy</a> of another

--- a/specs/referrer-policy/index.src.html
+++ b/specs/referrer-policy/index.src.html
@@ -607,10 +607,6 @@ urlPrefix: http://www.w3.org/TR/html5/
     <dd><a><code>No Referrer</code></a></dd>
     <dt>origin</dt>
     <dd><a><code>Origin</code></a></dd>
-    <dt>no-referrer-when-downgrade</dt>
-    <dd><a><code>No Referrer When Downgrade</code></a></dd>
-    <dt>origin-when-crossorigin</dt>
-    <dd><a><code>Origin When Cross-Origin</code></a></dd>
     <dt>unsafe-url</dt>
     <dd><a><code>Unsafe URL</code></a></dd>
   </dl>

--- a/specs/referrer-policy/index.src.html
+++ b/specs/referrer-policy/index.src.html
@@ -451,6 +451,9 @@ urlPrefix: http://www.w3.org/TR/html5/
       Via a <{meta}> element with a <{meta/name}> of <code>referrer</code>.
     </li>
     <li>
+      Via a <code>referrer</code> attribute on an <{a}> or <{area}> element.
+    </li>
+    <li>
       Implicitly, via inheritance.
     </li>
   </ul>
@@ -582,6 +585,37 @@ urlPrefix: http://www.w3.org/TR/html5/
       speculative resource loads.
     </dd>
   </dl>
+
+  <h3 id="referrer-policy-delivery-referrer-attribute">Delivery
+  via a <code>referrer</code> attribute</h3>
+
+  A referrer policy may be set when a <code>referrer</code> attribute is
+  added to an <code><a element>a</a></code> or <code><a element>area</a></code>
+  element, for example:
+
+  <pre class="example">
+    &lt;a href="http://example.com" referrer="origin"&gt;
+  </pre>
+
+  The following values for the <code>referrer</code> attribute are valid,
+  and map to the listed <a>referrer policy</a> values:
+
+  <dl>
+    <dt>no-referrer</dt>
+    <dd><a><code>No Referrer</code></a></dd>
+    <dt>origin</dt>
+    <dd><a><code>Origin</code></a></dd>
+    <dt>no-referrer-when-downgrade</dt>
+    <dd><a><code>No Referrer When Downgrade</code></a></dd>
+    <dt>origin-when-crossorigin</dt>
+    <dd><a><code>Origin When Cross-Origin</code></a></dd>
+    <dt>unsafe-url</dt>
+    <dd><a><code>Unsafe URL</code></a></dd>
+  </dl>
+
+  A policy delivered via a <code>referrer</code> attribute on an element
+  takes precedence over the policy defined for the whole document via CSP or
+  a <a element>meta</a> element.
 
   <h3 id="referrer-policy-delivery-implicit">Implicit Delivery</h3>
 

--- a/specs/referrer-policy/index.src.html
+++ b/specs/referrer-policy/index.src.html
@@ -735,6 +735,9 @@ urlPrefix: http://www.w3.org/TR/html5/
   <code>referrer</code> will be <code>no referrer</code>, and Fetch won't call
   into this algorithm.
 
+  ISSUE: This algorithm needs to be modifed to take into account any local
+  overrides via the referrer attribute on elements.
+
   <ol>
     <li>
       Let <var>environment</var> be <var>request</var>'s <code>client</code>.


### PR DESCRIPTION
This delivery mechanism is meant to subsume the rel="noreferrer"
link type defined in the HTML5 spec:

  https://html.spec.whatwg.org/multipage/semantics.html#link-type-noreferrer

This would allow for the following use case:

- I don't want any referrers to be sent (i.e. global policy of
"no-referrer" delivered via <meta> or CSP)
- except for these two links that should reveal the origin of the
referring page (i.e. local policy of "origin" on the two <a> elements)