### PR TITLE
[CredentialManagement] Removed a step from Request a Credential with options algorithm

### DIFF
--- a/specs/credentialmanagement/index.src.html
+++ b/specs/credentialmanagement/index.src.html
@@ -755,15 +755,10 @@ type: constructor
       <strong>and</strong> terminate this algorithm.
     </li>
     <li>
-      If <var>settings</var>' <a>responsible document</a> is not the <a>active
-      document</a> in the <a>top-level browsing context</a>
-      If <var>environment</var> is not a <a>top-level browsing context</a>,
-    <li>
       If the result of executing the <a>Is Document a sufficiently secure
       context?</a> algorithm on <var>settings</var>' <a>responsible document</a>
       is <code>Insecure</code> then reject <var>promise</var> with a
       <code>SecurityError</code> <strong>and</strong> terminate this algorithm.
-    
     </li>
     <li>
       Let <var>origin</var> be the <a>origin</a> of the <var>environment</var>.


### PR DESCRIPTION
I think this step was left in the algorithm by mistake. It doesn't make sense anyway.

There's a significant difference in wording between the "security" steps in "Request a Credential with options" and "Save credential" algorithms. The commit here is just a cleanup, this issue needs more attention.