### PR TITLE
[CredentialManagement] Use of singular they instead of she

### DIFF
--- a/specs/credentialmanagement/index.src.html
+++ b/specs/credentialmanagement/index.src.html
@@ -313,8 +313,8 @@ type: constructor
     <h4 id="examples-change-password">Change Password</h4>
 
     The "Local Sign-In" mechanism can be reused for "password change" with no
-    modifications: if the user changes her credentials, the website can notify
-    the user agent that she's successfully signed in with new credentials. The
+    modifications: if the user changes their credentials, the website can notify
+    the user agent that they are successfully signed in with new credentials. The
     user agent can then update the credentials it stores.
   </section>
 
@@ -372,10 +372,10 @@ type: constructor
       <dfn export>Credentials</dfn>
     </dt>
     <dd>
-      A user authenticates herself to an <a>origin</a> by submitting a set of
+      A user authenticates themselves to an <a>origin</a> by submitting a set of
       <strong>credentials</strong>. This typically consists of either a
       username/password pair, or a pointer out to a <a>federated identity
-      provider</a> which will authenticate the user on her behalf.
+      provider</a> which will authenticate the user on their behalf.
     </dd>
 
     <dt>
@@ -788,7 +788,7 @@ type: constructor
           terminate this algorithm.
 
           Note: This requirement only applies if we would show UI to the user.
-          If she's elected to allow credentials to be provided without user
+          If they have elected to allow credentials to be provided without user
           mediation, and we can do so, then we don't require a user gesture
           for {{request()}}. Otherwise, we do, due to the considerations in
           [[#privacy-considerations]].
@@ -1081,8 +1081,8 @@ type: constructor
 
   Exposing credential information to the web via an API has a number of
   potential impacts on user privacy. The user agent, therefore, MUST
-  involve the user in a number of cases in order to ensure that she clearly
-  understands what's going on, and with whom her credentials are being shared.
+  involve the user in a number of cases in order to ensure that they clearly
+  understands what's going on, and with whom their credentials are being shared.
 
   <h3 id="user-mediated-storage">Storing and Updating Credentials</h3>
 
@@ -1154,7 +1154,7 @@ type: constructor
       similar location.
     </li>
     <li>
-      If a user clears her browsing data for an origin (cookies, localStorage,
+      If a user clears their browsing data for an origin (cookies, localStorage,
       and so on), the user agent MUST require user mediation for that origin
       by executing the algorithm defined in
       [[#require-user-mediation-for-origin]].
@@ -1167,7 +1167,7 @@ type: constructor
   that are available without user mediation, user agents MUST ask the user for
   permission to share credential information. This SHOULD take the form of a
   <dfn local-lt="chooser">credential chooser</dfn> which presents the user
-  with a list of credentials that are available for use on a site, allowing her
+  with a list of credentials that are available for use on a site, allowing them
   to select one which should be provided to the website, or to reject the
   request entirely.
 
@@ -1331,7 +1331,7 @@ type: constructor
   {{CredentialRequestOptions/federations}} array. The risk is mitigated by the
   fact that a user-mediated {{request()}} is tied to a user gesture, and the
   user would, sooner or later, be prompted to provide credentials to the site,
-  which would certainly raise her suspicions as to its behavior.
+  which would certainly raise their suspicions as to its behavior.
 
 
   <h3 id="privacy-chooser-leakage">Chooser Leakage</h3>


### PR DESCRIPTION
I think that using the feminine pronouns in place of "user" noun is not quite correct English. Non English native-speakers might even be mislead into thinking that the noun user is of feminine gender.

The commit below changes most (all) such occurrences to use the "singular they" pronoun forms.