### PR TITLE
CREDENTIAL: Fix for "top-level browsing context" dfn href

### DIFF
--- a/specs/credentialmanagement/index.src.html
+++ b/specs/credentialmanagement/index.src.html
@@ -25,7 +25,7 @@ type: dfn
     urlPrefix: browsers.html
       text: allowed to show a popup
       text: browsing context
-      text: top-level browsing context
+      text: top-level browsing context; url: top-level-browsing-context
       text: nested browsing context
       text: active document
   urlPrefix: https://tools.ietf.org/html/rfc6454


### PR DESCRIPTION
The "-" was converted to "_" in href anchor.

Please first check with bikeshed if this solves the problem