### PR TITLE
Clarify the conditionality of the upgrade mechanism

### DIFF
--- a/specs/upgrade/index.src.html
+++ b/specs/upgrade/index.src.html
@@ -420,7 +420,15 @@ spec: RFC7240; urlPrefix: https://tools.ietf.org/html/rfc7240
   user-agent sniffing to make this decision, user agents MUST advertise their
   capabilities when making navigational requests by sending a
   <code>Prefer</code> HTTP request header expressing the desire for a secure
-  representation [[!RFC7240]] as described in [[#preference]].
+  representation [[!RFC7240]] as described in [[#preference]], unless they
+  have an HSTS directive active for the request's origin.
+
+  If a client has an HSTS state set for a given origin, the only reason to
+  send the <code>Prefer: tls</code> header is to trigger retransmission of the
+  HSTS header to extend its <code>max-age</code>.  Accordingly, clients SHOULD
+  send the <code>Prefer: tls</code> header if the <code>max-age</code> for an
+  origin's HSTS directive is three-quarters expired, and/or send <code>Prefer:
+  tls</code> with some small probability on each request.
 
   <h4 id="preference">
     The <code>tls</code> Preference

--- a/specs/upgrade/index.src.html
+++ b/specs/upgrade/index.src.html
@@ -307,6 +307,13 @@ spec: RFC7240; urlPrefix: https://tools.ietf.org/html/rfc7240
   :: A {{Request}} is said to be <strong>upgraded</strong> if it is rewritten
      to contain a URL with a {{URL/scheme}} of <code>https</code> or
      <code>wss</code>.
+  :  <dfn export>safely upgradable requests</dfn>
+  ::  If an origin does not depend on this document's
+      <code><a>upgrade-insecure-requests</a></code> mechanism, all requests to
+      it are considered <strong>safely upgradable requests</strong>.  If an
+      origin depends on the upgrade-insecure mechanism, only requests from
+      clients that send a <a>Prefer</a>: <a>return=secure-representation</a> header are
+      considered <strong>safely upgradable requests</strong>.
 
   The Augmented Backus-Naur Form (ABNF) notation used in [[#delivery]] is
   specified in RFC5234. [[!ABNF]]
@@ -847,12 +854,9 @@ spec: RFC7240; urlPrefix: https://tools.ietf.org/html/rfc7240
   <ol>
     <li>
       Determine if any pages on the origin are dependent on the
-      <code><a>upgrade-insecure-requests</a></code> mechanism. If so, requests
-      that contain a <a>Prefer</a>: <a>return=secure-representation</a> header are
-      considered <dfn export>safely upgradable requests</dfn>, while requests without
-      this header are not <a>safely upgradable requests</a>.  If no pages on the
-      origin depend on <code><a>upgrade-insecure-requests</a></code>, all
-      requests are <a>safely upgradable requests</a>.
+      <code><a>upgrade-insecure-requests</a></code> mechanism, and
+      accordingly, which inbound requests are <a>safely upgradable
+      requests</a>.
     <li>
       Redirect incoming <a>safely upgradable requests</a> from HTTP to HTTPS by serving a
       <code>Location</code> header along with a <code>302</code> status code.

--- a/specs/upgrade/index.src.html
+++ b/specs/upgrade/index.src.html
@@ -854,7 +854,7 @@ spec: RFC7240; urlPrefix: https://tools.ietf.org/html/rfc7240
       origin depend on <code><a>upgrade-insecure-requests</a></code>, all
       requests are <a>safely upgradable requests</a>.
     <li>
-      Redirect incoming <a>safely upgradable requests<a> from HTTP to HTTPS by serving a
+      Redirect incoming <a>safely upgradable requests</a> from HTTP to HTTPS by serving a
       <code>Location</code> header along with a <code>302</code> status code.
     </li>
     <li>

--- a/specs/upgrade/index.src.html
+++ b/specs/upgrade/index.src.html
@@ -404,11 +404,12 @@ spec: RFC7240; urlPrefix: https://tools.ietf.org/html/rfc7240
   If a site requires the upgrade mechanism described in this document in order
   to provide users with a reasonable experience over secure transit, then
   authors need to determine whether or not it is safe to redirect a client to
-  the secure version of a site. Rather than relying on user-agent sniffing to
-  make this decision, user agents MUST advertise their capabilities when
-  making insecure navigational requests by sending a <code>Prefer</code> HTTP
-  request header expressing the desire for a secure representation [[!RFC7240]]
-  as described in [[#preference]].
+  the secure version of a site, or set an HSTS header if the request is
+  already to a <a>potentially secure origin</a>. Rather than relying on
+  user-agent sniffing to make this decision, user agents MUST advertise their
+  capabilities when making navigational requests by sending a
+  <code>Prefer</code> HTTP request header expressing the desire for a secure
+  representation [[!RFC7240]] as described in [[#preference]].
 
   <h4 id="preference">
     The <code>return=secure-representation</code> Preference
@@ -435,10 +436,7 @@ spec: RFC7240; urlPrefix: https://tools.ietf.org/html/rfc7240
   response should include a Strict Transport Security header [[RFC6797]].
 
   User agent implementation details are described in step #2 of the the
-  [[#upgrade-request]] algorithm. Note in particular that to mitigate the risk
-  that this header will become a vestigial part of the platform, user agents
-  SHOULD omit the preference when making requests to <a>potentially secure
-  origins</a>.
+  [[#upgrade-request]] algorithm.
 
   <div class="example">
     A client that supports this document's upgrade mechanism requests
@@ -619,10 +617,6 @@ spec: RFC7240; urlPrefix: https://tools.ietf.org/html/rfc7240
   #3.
 
   <ol>
-    <li>
-      If <var>request</var>'s {{Request/url}} is <a>potentially secure</a>:
-      return without modifying <var>request</var>.
-    </li>
     <li>
       If <var>request</var>'s {{Request/context-frame-type}} is
       <code>top-level</code>, <code>nested</code>, or <code>auxiliary</code>,
@@ -852,23 +846,34 @@ spec: RFC7240; urlPrefix: https://tools.ietf.org/html/rfc7240
 
   <ol>
     <li>
-      Redirect incoming traffic from HTTP to HTTPS by serving a
+      Determine if any pages on the origin are dependent on the
+      <code><a>upgrade-insecure-requests</a></code> mechanism. If so, requests
+      that contain a <a>Prefer</a>: <a>return=secure-representation</a> header are
+      considered <dfn export>safely upgradable requests</dfn>, while requests without
+      this header are not <a>safely upgradable requests</a>.  If no pages on the
+      origin depend on <code><a>upgrade-insecure-requests</a></code>, all
+      requests are <a>safely upgradable requests</a>.
+    <li>
+      Redirect incoming <a>safely upgradable requests<a> from HTTP to HTTPS by serving a
       <code>Location</code> header along with a <code>302</code> status code.
     </li>
     <li>
-      Respond to HTTPS requests with a <code>Strict-Transport-Security</code>
-      header with a reasonable <code>max-age</code>.
+      Respond to HTTPS <a>safely upgradable requests</a> with a
+      <code>Strict-Transport-Security</code> header with a reasonable
+      <code>max-age</code>.
     </li>
     <li>
-      Work with user agent vendors to add their sites to those user agent's
-      HSTS Preload Lists (for example, by visiting
-      <a href="https://hstspreload.appspot.com/">hstspreload.appspot.com</a>).
-    </li>
-    <li>
-      Opt-into either this document's
-      <code><a>upgrade-insecure-requests</a></code> mechanism, or into Mixed
-      Content's <a>strict mode</a> in order to ensure that insecure content is
-      never loaded.
+      If some pages on the origin require
+      <code><a>upgrade-insecure-requests</a></code> mechanism, then opt in to
+      it.
+
+      If no pages on the origin require
+      <code><a>upgrade-insecure-requests</a></code> to function securely, work
+      with user agent vendors to add their sites to those user agent's HSTS
+      Preload Lists (for example, by visiting <a
+      href="https://hstspreload.appspot.com/">hstspreload.appspot.com</a>) and
+      enable Mixed Content's <a>strict mode</a> in order to ensure that insecure
+      content is never loaded.
     </li>
   </ol>
 </section>

--- a/specs/upgrade/index.src.html
+++ b/specs/upgrade/index.src.html
@@ -316,7 +316,7 @@ spec: RFC7240; urlPrefix: https://tools.ietf.org/html/rfc7240
       <code><a>upgrade-insecure-requests</a></code> mechanism, all requests to
       it are considered <strong>safely upgradable requests</strong>.  If an
       origin depends on the upgrade-insecure mechanism, only requests from
-      clients that send a <a>Prefer</a>: <a>return=secure-representation</a> header are
+      clients that send a <a>Prefer</a>: <a>tls</a> header are
       considered <strong>safely upgradable requests</strong>.
 
   The Augmented Backus-Naur Form (ABNF) notation used in [[#delivery]] is
@@ -903,7 +903,7 @@ spec: RFC7240; urlPrefix: https://tools.ietf.org/html/rfc7240
   [[!RFC7240]]:
 
   :  Preference
-  :: https
+  :: tls
 
   :  Description
   :: This preference indicates that the client prefers that the server return

--- a/specs/upgrade/index.src.html
+++ b/specs/upgrade/index.src.html
@@ -421,14 +421,15 @@ spec: RFC7240; urlPrefix: https://tools.ietf.org/html/rfc7240
   capabilities when making navigational requests by sending a
   <code>Prefer</code> HTTP request header expressing the desire for a secure
   representation [[!RFC7240]] as described in [[#preference]], unless they
-  have an HSTS directive active for the request's origin.
+  have an HSTS state with a "mixed-safe" directive active for the request's origin.
 
-  If a client has an HSTS state set for a given origin, the only reason to
-  send the <code>Prefer: tls</code> header is to trigger retransmission of the
-  HSTS header to extend its <code>max-age</code>.  Accordingly, clients SHOULD
-  send the <code>Prefer: tls</code> header if the <code>max-age</code> for an
-  origin's HSTS directive is three-quarters expired, and/or send <code>Prefer:
-  tls</code> with some small probability on each request.
+  If a client has an "mixed-safe" HSTS state set for a given origin, the only
+  reason to send the <code>Prefer: tls</code> header is to trigger
+  retransmission of the HSTS header to extend its <code>max-age</code>.
+  Accordingly, clients SHOULD send the <code>Prefer: tls</code> header if the
+  <code>max-age</code> for an origin's HSTS directive is three-quarters
+  expired, and/or send <code>Prefer: tls</code> with some small probability on
+  each request.
 
   <h4 id="preference">
     The <code>tls</code> Preference
@@ -894,7 +895,9 @@ spec: RFC7240; urlPrefix: https://tools.ietf.org/html/rfc7240
       it.
 
       If no pages on the origin require
-      <code><a>upgrade-insecure-requests</a></code> to function securely, work
+      <code><a>upgrade-insecure-requests</a></code> to function securely, add
+      the <code>mixed-safe</code> directive to the
+      <code>Strict-Transport-Security</code> header.  Additionally, work
       with user agent vendors to add their sites to those user agent's HSTS
       Preload Lists (for example, by visiting <a
       href="https://hstspreload.appspot.com/">hstspreload.appspot.com</a>) and


### PR DESCRIPTION
* The client must unfortunately send the "Prefer: return=secure-representation"
  header for all navigational requests, because HSTS will always need to be
  conditional on it.

* Clarify deployment advice with the concept of a "safely upgradable request",
  which is either a request to a mixed-content free origin, or a request from
  a client that supports the new upgrade mechanism.

* Refactor deployment advice generally.