### PR TITLE
SRI: Fix ABNF

### DIFF
--- a/specs/subresourceintegrity/index.html
+++ b/specs/subresourceintegrity/index.html
@@ -664,10 +664,12 @@ for all possible subresources, i.e., <code>a</code>, <code>audio</code>, <code>e
 The value of the attribute MUST be either the empty string, or at least one
 valid metadata as described by the following ABNF grammar:</p>
 
-    <pre><code>integrity-metadata = *WSP [ option-expression *( 1*WSP option-expression ) *WSP ] hash-expression *( 1*WSP hash-expression ) *WSP / *WSP
-option-expression  =  option-name ":" [ option-value ]
-option-name        = ALPHA / DIGIT / "-"
-option-value       = ALPHA / DIGIT / "-" / "+" / "." / "/"
+    <pre><code>integrity-metadata = *WSP [ option-expression *( 1*WSP option-expression ) 1*WSP ] hash-expression *( 1*WSP hash-expression ) *WSP / *WSP
+option-expression  = option-name ":" option-value
+option-name        = 1*option-name-char
+option-name-char   = ALPHA / DIGIT / "-"
+option-value       = *option-value-char
+option-value-char  = ALPHA / DIGIT / "-" / "+" / "." / "/"
 hash-algo          = &lt;hash-algo production from [Content Security Policy Level 2, section 4.2]&gt;
 base64-value       = &lt;base64-value production from [Content Security Policy Level 2, section 4.2]&gt;
 hash-expression    = hash-algo "-" base64-value

--- a/specs/subresourceintegrity/spec.markdown
+++ b/specs/subresourceintegrity/spec.markdown
@@ -529,10 +529,12 @@ The `integrity` attribute represents [integrity metadata][] for an element.
 The value of the attribute MUST be either the empty string, or at least one
 valid metadata as described by the following ABNF grammar:
 
-    integrity-metadata = *WSP [ option-expression *( 1*WSP option-expression ) *WSP ] hash-expression *( 1*WSP hash-expression ) *WSP / *WSP
-    option-expression  =  option-name ":" [ option-value ]
-    option-name        = ALPHA / DIGIT / "-"
-    option-value       = ALPHA / DIGIT / "-" / "+" / "." / "/"
+    integrity-metadata = *WSP [ option-expression *( 1*WSP option-expression ) 1*WSP ] hash-expression *( 1*WSP hash-expression ) *WSP / *WSP
+    option-expression  = option-name ":" option-value
+    option-name        = 1*option-name-char
+    option-name-char   = ALPHA / DIGIT / "-"
+    option-value       = *option-value-char
+    option-value-char  = ALPHA / DIGIT / "-" / "+" / "." / "/"
     hash-algo          = <hash-algo production from [Content Security Policy Level 2, section 4.2]>
     base64-value       = <base64-value production from [Content Security Policy Level 2, section 4.2]>
     hash-expression    = hash-algo "-" base64-value


### PR DESCRIPTION
Require a whitespace between option-expression and hash-expression;
And allow multiple characters in option-value