### PR TITLE
SRI: Use an equal sign in option-expression

### DIFF
--- a/specs/subresourceintegrity/index.html
+++ b/specs/subresourceintegrity/index.html
@@ -143,7 +143,7 @@ substitute malicious content.</p>
 <code>script</code> element, like so:</p>
 
   <pre><code>&lt;script src="https://code.jquery.com/jquery-1.10.2.min.js"
-        integrity="type:application/javascript
+        integrity="type=application/javascript
                    sha256-C6CB9UYIS9UJeqinPHWTHVqh/E1uhG5Twh+Y5qFQmYg="&gt;
 </code></pre>
 
@@ -198,7 +198,7 @@ behavior) would change her code in unfortunate ways by adding
 <a href="#dfn-integrity-metadata">integrity metadata</a> to the <code>link</code> element included on her page:</p>
 
           <pre class="example highlight"><code>&lt;link rel="stylesheet" href="https://site53.cdn.net/style.css"
-      integrity="type:text/css sha256-SDfwewFAE...wefjijfE"&gt;
+      integrity="type=text/css sha256-SDfwewFAE...wefjijfE"&gt;
 </code></pre>
         </li>
         <li>
@@ -209,7 +209,7 @@ the code she’s carefully reviewed is executed. She can do so by generating
 adding it to the <code>script</code> element she includes on her page:</p>
 
           <pre class="example highlight"><code>&lt;script src="https://analytics-r-us.com/v1.0/include.js"
-        integrity="type:application/javascript
+        integrity="type=application/javascript
                    sha256-SDfwewFAE...wefjijfE"&gt;&lt;/script&gt;
 </code></pre>
         </li>
@@ -321,7 +321,7 @@ digest that results. This can be encoded as follows:</p>
 
     <p>Or, if the author further wishes to specify the Content Type (<code>application/javascript</code>):</p>
 
-    <pre class="example highlight"><code>type:application/javascript sha256-qznLcsROx4GACP2dm0UCKCzCG+HiZ1guq6ZZDob/Tng=
+    <pre class="example highlight"><code>type=application/javascript sha256-qznLcsROx4GACP2dm0UCKCzCG+HiZ1guq6ZZDob/Tng=
 </code></pre>
 
     <div class="note">
@@ -359,7 +359,7 @@ sha512-rQw3wx1psxXzqB8TyM3nAQlK2RcluhsNwxmcqXE2YbgoDW735o8TPmIR4uWpoxUERddvFwjgR
       <p>Authors may choose to specify both, for example:</p>
 
       <pre><code>&lt;script src="hello_world.js"
-   integrity="type:application/javascript
+   integrity="type=application/javascript
       sha256-+MO/YqmqPm/BYZwlDkir51GTc9Pt9BvmLrXcRRma8u8=
       sha512-rQw3wx1psxXzqB8TyM3nAQlK2RcluhsNwxmcqXE2YbgoDW735o8TPmIR4uWpoxUERddvFwjgRSGw7gNPCwuvJg==
     "&gt;&lt;/script&gt;

--- a/specs/subresourceintegrity/index.html
+++ b/specs/subresourceintegrity/index.html
@@ -680,7 +680,7 @@ The value of the attribute MUST be either the empty string, or at least one
 valid metadata as described by the following ABNF grammar:</p>
 
     <pre><code>integrity-metadata = *WSP [ option-expression *( 1*WSP option-expression ) 1*WSP ] hash-expression *( 1*WSP hash-expression ) *WSP / *WSP
-option-expression  = option-name ":" option-value
+option-expression  = option-name "=" option-value
 option-name        = 1*option-name-char
 option-name-char   = ALPHA / DIGIT / "-"
 option-value       = *option-value-char

--- a/specs/subresourceintegrity/spec.markdown
+++ b/specs/subresourceintegrity/spec.markdown
@@ -45,7 +45,7 @@ This example can be communicated to a user agent by adding the hash to a
 `script` element, like so:
 
     <script src="https://code.jquery.com/jquery-1.10.2.min.js"
-            integrity="type:application/javascript
+            integrity="type=application/javascript
                        sha256-C6CB9UYIS9UJeqinPHWTHVqh/E1uhG5Twh+Y5qFQmYg=">
 
 {:.example.highlight}
@@ -96,7 +96,7 @@ regardless of the URL from which they are loaded.
     [integrity metadata][] to the `link` element included on her page:
 
         <link rel="stylesheet" href="https://site53.cdn.net/style.css"
-              integrity="type:text/css sha256-SDfwewFAE...wefjijfE">
+              integrity="type=text/css sha256-SDfwewFAE...wefjijfE">
     {:.example.highlight}
 
 *   An author wants to include JavaScript provided by a third-party
@@ -106,7 +106,7 @@ regardless of the URL from which they are loaded.
     adding it to the `script` element she includes on her page:
 
         <script src="https://analytics-r-us.com/v1.0/include.js"
-                integrity="type:application/javascript
+                integrity="type=application/javascript
                            sha256-SDfwewFAE...wefjijfE"></script>
     {:.example.highlight}
 
@@ -225,7 +225,7 @@ digest that results. This can be encoded as follows:
 
 Or, if the author further wishes to specify the Content Type (`application/javascript`):
 
-    type:application/javascript sha256-qznLcsROx4GACP2dm0UCKCzCG+HiZ1guq6ZZDob/Tng=
+    type=application/javascript sha256-qznLcsROx4GACP2dm0UCKCzCG+HiZ1guq6ZZDob/Tng=
 {:.example.highlight}
 
 <div class="note">
@@ -267,7 +267,7 @@ either of the following `ni` URLs:
 Authors may choose to specify both, for example:
 
     <script src="hello_world.js"
-       integrity="type:application/javascript
+       integrity="type=application/javascript
           sha256-+MO/YqmqPm/BYZwlDkir51GTc9Pt9BvmLrXcRRma8u8=
           sha512-rQw3wx1psxXzqB8TyM3nAQlK2RcluhsNwxmcqXE2YbgoDW735o8TPmIR4uWpoxUERddvFwjgRSGw7gNPCwuvJg==
         "></script>

--- a/specs/subresourceintegrity/spec.markdown
+++ b/specs/subresourceintegrity/spec.markdown
@@ -562,7 +562,7 @@ The value of the attribute MUST be either the empty string, or at least one
 valid metadata as described by the following ABNF grammar:
 
     integrity-metadata = *WSP [ option-expression *( 1*WSP option-expression ) 1*WSP ] hash-expression *( 1*WSP hash-expression ) *WSP / *WSP
-    option-expression  = option-name ":" option-value
+    option-expression  = option-name "=" option-value
     option-name        = 1*option-name-char
     option-name-char   = ALPHA / DIGIT / "-"
     option-value       = *option-value-char


### PR DESCRIPTION
Use of the equals sign has precedent in many protocols and syntaxes including HTTP, MIME, and HTML.
This production is forward-compatible with most all of them, e.g. quoted-string or urlencoded.