### PR TITLE
Fixing some easy nits from

### DIFF
--- a/specs/subresourceintegrity/index.html
+++ b/specs/subresourceintegrity/index.html
@@ -147,16 +147,10 @@ substitute malicious content.</p>
                    sha256-C6CB9UYIS9UJeqinPHWTHVqh/E1uhG5Twh+Y5qFQmYg="&gt;
 </code></pre>
 
-  <p>Scripts, of course, are not the only resource type which would benefit
+  <p class="example highlight">Scripts, of course, are not the only resource type which would benefit
 from integrity validation. The scheme specified here applies to all HTML
 elements which trigger fetches, as well as to fetches triggered from CSS
 and JavaScript.</p>
-
-  <p>Moreover, integrity metadata may also be useful for purposes other than
-validation. User agents may decide to use the integrity metadata as an
-identifier in a local cache, for instance, meaning that common resources
-(for example, JavaScript libraries) could be cached and retrieved once,
-regardless of the URL from which they are loaded.</p>
 
   <section>
     <h3 id="goals">Goals</h3>
@@ -266,7 +260,7 @@ is an origin whose scheme component is <code>HTTPS</code>.</p>
 and format of that resource. [[!MIMETYPE]]</p>
 
     <p>The <dfn>message body</dfn> and the <dfn>transfer encoding</dfn> of a resource
-are defined by <a href="http://tools.ietf.org/html/rfc7230#section-3">RFC7230, section 3</a>. [[!RFC7230]] </p>
+are defined by <a href="http://tools.ietf.org/html/rfc7230#section-3">RFC7230, section 3</a>. [[!RFC7230]]</p>
 
     <p>The <dfn>representation data</dfn> and <dfn>content encoding</dfn> of a resource
 are defined by <a href="http://tools.ietf.org/html/rfc7231#section-3">RFC7231, section 3</a>. [[!RFC7231]]</p>
@@ -350,7 +344,7 @@ resource’s <a href="#dfn-integrity-metadata">integrity metadata</a>, and MAY s
       <p>Multiple sets of <a href="#dfn-integrity-metadata">integrity metadata</a> may be associated with a single
 resource in order to provide agility in the face of future discoveries.
 For example, the “Hello, world.” resource described above may be described
-either of the following <code>ni</code> URLs:</p>
+either of the following hash expressions:</p>
 
       <pre class="example highlight"><code>sha256-+MO/YqmqPm/BYZwlDkir51GTc9Pt9BvmLrXcRRma8u8=
 sha512-rQw3wx1psxXzqB8TyM3nAQlK2RcluhsNwxmcqXE2YbgoDW735o8TPmIR4uWpoxUERddvFwjgRSGw7gNPCwuvJg==
@@ -386,8 +380,9 @@ stronger hash functions as they become available.</p>
       <h4 id="priority">Priority</h4>
 
       <p>User agents MUST provide a mechanism of determining the relative priority of
-two hash functions. That is, <dfn>getPrioritizedHashFunction(a, b)</dfn> MUST
-return the hash function the user agent considers the most collision-resistant.
+two hash functions. That is, if a user agent implemented a function like
+<dfn>getPrioritizedHashFunction(a, b)</dfn> it would return the hash function
+the user agent considers the most collision-resistant.
 For example, <code>getPrioritizedHashFunction('SHA-256', 'SHA-512')</code> would return
 <code>SHA-512</code>.</p>
 
@@ -488,7 +483,7 @@ checking because it won’t have loaded successfully.</p>
       <h4 id="parse-varmetadatavar">Parse <var>metadata</var>.</h4>
 
       <p>This algorithm accepts a string, and returns either <code>no metadata</code>, or a set of
-valid “named information” (<code>ni</code>) URLs whose hash functions are understood by
+valid hash expressions whose hash functions are understood by
 the user agent.</p>
 
       <ol>

--- a/specs/subresourceintegrity/spec.markdown
+++ b/specs/subresourceintegrity/spec.markdown
@@ -55,12 +55,6 @@ from integrity validation. The scheme specified here applies to all HTML
 elements which trigger fetches, as well as to fetches triggered from CSS
 and JavaScript.
 
-Moreover, integrity metadata may also be useful for purposes other than
-validation. User agents may decide to use the integrity metadata as an
-identifier in a local cache, for instance, meaning that common resources
-(for example, JavaScript libraries) could be cached and retrieved once,
-regardless of the URL from which they are loaded.
-
 [HSTS]: http://tools.ietf.org/html/rfc6797
 [pinned public keys]: http://tools.ietf.org/html/draft-ietf-websec-key-pinning
 

--- a/specs/subresourceintegrity/spec.markdown
+++ b/specs/subresourceintegrity/spec.markdown
@@ -252,7 +252,7 @@ resource's [integrity metadata][], and MAY support additional hash functions.
 Multiple sets of [integrity metadata][] may be associated with a single
 resource in order to provide agility in the face of future discoveries.
 For example, the "Hello, world." resource described above may be described
-either of the following `ni` URLs:
+either of the following hash expressions:
 
     sha256-+MO/YqmqPm/BYZwlDkir51GTc9Pt9BvmLrXcRRma8u8=
     sha512-rQw3wx1psxXzqB8TyM3nAQlK2RcluhsNwxmcqXE2YbgoDW735o8TPmIR4uWpoxUERddvFwjgRSGw7gNPCwuvJg==
@@ -390,7 +390,7 @@ checking because it won't have loaded successfully.
 #### Parse <var>metadata</var>.
 
 This algorithm accepts a string, and returns either `no metadata`, or a set of
-valid "named information" (`ni`) URLs whose hash functions are understood by
+valid hash expressions whose hash functions are understood by
 the user agent.
 
 1.  If <var>metadata</var> is the empty string, return `no metadata`.

--- a/specs/subresourceintegrity/spec.markdown
+++ b/specs/subresourceintegrity/spec.markdown
@@ -292,8 +292,9 @@ stronger hash functions as they become available.
 #### Priority
 
 User agents MUST provide a mechanism of determining the relative priority of
-two hash functions. That is, <dfn>getPrioritizedHashFunction(a, b)</dfn> MUST
-return the hash function the user agent considers the most collision-resistant.
+two hash functions. That is, if a user agent implemented a function like
+<dfn>getPrioritizedHashFunction(a, b)</dfn> it would return the hash function
+the user agent considers the most collision-resistant.
 For example, `getPrioritizedHashFunction('SHA-256', 'SHA-512')` would return
 `SHA-512`.
 


### PR DESCRIPTION
Fixing the following from issue #217:

* 3.2.2 definition of getPrioritizedHashFunction?
* 3.2.1 agility still mentions ni URLs
* 3.3.3 talks about set of valid 'named information' links
* 1. introduction still talks about cache identifiers: "I think it's best to remove this, as it's speculative."