### PR TITLE
"CSP"-Header ABNF adjusted

### DIFF
--- a/specs/CSP2/index.html
+++ b/specs/CSP2/index.html
@@ -1079,7 +1079,7 @@
      
 
     
-     <pre>"CSP:" 1#<a data-link-type="dfn" href="#csp_header_value">csp-header-value</a>
+     <pre>"CSP:" <a data-link-type="dfn" href="#csp_header_value">csp-header-value</a>
 
 <dfn data-dfn-type="dfn" data-noexport="" id="csp_header_value">csp-header-value<a class="self-link" href="#csp_header_value"></a></dfn> = *WSP "active" *WSP
 </pre>

--- a/specs/CSP2/index.src.html
+++ b/specs/CSP2/index.src.html
@@ -695,7 +695,7 @@ type: method
     following ABNF grammar:
 
     <pre>
-      "CSP:" 1#<a>csp-header-value</a>
+      "CSP:" <a>csp-header-value</a>
 
       <dfn>csp-header-value</dfn> = *WSP "active" *WSP
     </pre>


### PR DESCRIPTION
With the current ABNF the following header is possible:
CSP:     active    ,     active, active, active, active      

I think that's not intended.