### PR TITLE
Use [SRI] as the list prefix

### DIFF
--- a/specs/subresourceintegrity/template.erb
+++ b/specs/subresourceintegrity/template.erb
@@ -37,7 +37,7 @@
 
         // name (with the @w3c.org) of the public mailing to which comments are due
         wgPublicList: "public-webappsec",
-        subjectPrefix: "[Integrity]",
+        subjectPrefix: "[SRI]",
 
         // URI of the patent status for this WG, for Rec-track documents
         // !!!! IMPORTANT !!!!


### PR DESCRIPTION
`[Integrity]` is a bit long and `[SRI]` seems to be the one that most people
have settled on despite the abstract suggesting `[Integrity]`.