### PR TITLE
Expand option-value-char characters

### DIFF
--- a/specs/subresourceintegrity/index.html
+++ b/specs/subresourceintegrity/index.html
@@ -695,7 +695,7 @@ option-expression  = option-name "=" option-value
 option-name        = 1*option-name-char
 option-name-char   = ALPHA / DIGIT / "-"
 option-value       = *option-value-char
-option-value-char  = ALPHA / DIGIT / "-" / "+" / "." / "/"
+option-value-char  = ALPHA / DIGIT / "!" / "#" / "$" / "%" / "&amp;" / "'" / "*" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" / "/"
 hash-algo          = &lt;hash-algo production from [Content Security Policy Level 2, section 4.2]&gt;
 base64-value       = &lt;base64-value production from [Content Security Policy Level 2, section 4.2]&gt;
 hash-expression    = hash-algo "-" base64-value

--- a/specs/subresourceintegrity/spec.markdown
+++ b/specs/subresourceintegrity/spec.markdown
@@ -549,7 +549,7 @@ valid metadata as described by the following ABNF grammar:
     option-name        = 1*option-name-char
     option-name-char   = ALPHA / DIGIT / "-"
     option-value       = *option-value-char
-    option-value-char  = ALPHA / DIGIT / "-" / "+" / "." / "/"
+    option-value-char  = ALPHA / DIGIT / "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" / "/"
     hash-algo          = <hash-algo production from [Content Security Policy Level 2, section 4.2]>
     base64-value       = <base64-value production from [Content Security Policy Level 2, section 4.2]>
     hash-expression    = hash-algo "-" base64-value


### PR DESCRIPTION
This expands option-value-chars to a much wider array of characters as per @mnot's suggestion in #217. Note, however, that this also adds "/" as a character since we hope to support MIME type's in the future, and those distinctly use "/".