### PR TITLE
CREDENTIAL: mismatch of "type" value between note and example

### DIFF
--- a/specs/credentialmanagement/index.src.html
+++ b/specs/credentialmanagement/index.src.html
@@ -602,7 +602,7 @@ spec: URL; urlPrefix: http://www.w3.org/TR/url/
     <dt>{{[[type]]}}</dt>
     <dd>
       All {{PasswordCredential}} objects have their {{[[type]]}} slot's
-      value set to <code>password</code>.
+      value set to <code>"PasswordCredential"</code>.
     </dd>
   </dl>
 

--- a/specs/credentialmanagement/index.src.html
+++ b/specs/credentialmanagement/index.src.html
@@ -248,7 +248,7 @@ spec: URL; urlPrefix: http://www.w3.org/TR/url/
                 // really be progressive enhancement on top of an existing form).
                 return;
               }
-              if (credential.type == "PasswordCredential") {
+              if (credential.type == "password") {
                 credential.<a method lt="send()">send</a>("https://example.com/loginEndpoint")
                   .then(function (response) {
                     // Notify the user that signin succeeded! Do amazing, signed-in things!


### PR DESCRIPTION
The text in 
http://w3c.github.io/webappsec/specs/credentialmanagement/#passwordcredential

[[type]]
    All PasswordCredential objects have their [[type]] slot’s value set to password.

while the example 
http://w3c.github.io/webappsec/specs/credentialmanagement/#examples-password-signin
has this code:
if (credential.type == "PasswordCredential") {

I think the text should be changed to:
[[type]]
    All PasswordCredential objects have their [[type]] slot’s value set to "PasswordCredential".
