### PR TITLE
SRI: Add section Security Considerations: Behavior of chameleon resources

### DIFF
--- a/specs/subresourceintegrity/index.html
+++ b/specs/subresourceintegrity/index.html
@@ -909,6 +909,22 @@ will likely be difficult to avoid (image’s <code>naturalHeight</code> and
   </section>
   <!-- /Security::cross-origin -->
 
+  <section>
+    <h3 id="behavior-of-chameleon-resources">Behavior of chameleon resources</h3>
+
+    <p>Resources may still exhibit differing behavior due to out-of-bound data
+like its media type, HTTP headers, or origin. Particularly, a “chameleon”
+resource is one that is valid under multiple media types. For example, a
+CSS document, validated as such to the server’s satisfaction, might still be
+crafted with malicious effects that are triggered if interperted as
+application/javascript.</p>
+
+    <p>Servers SHOULD NOT rely on “integrity” to ensure the safe behavior of
+user-generated content stored on untrusted/third party servers, even if
+the document is sanity/validity checked.</p>
+  </section>
+  <!-- /Security::behavior -->
+
 </section>
 <!-- /Security -->
 

--- a/specs/subresourceintegrity/spec.markdown
+++ b/specs/subresourceintegrity/spec.markdown
@@ -748,6 +748,21 @@ will likely be difficult to avoid (image's `naturalHeight` and
 `naturalWidth` for instance).
 </section><!-- /Security::cross-origin -->
 
+<section>
+### Behavior of chameleon resources
+
+Resources may still exhibit differing behavior due to out-of-bound data
+like its media type, HTTP headers, or origin. Particularly, a "chameleon"
+resource is one that is valid under multiple media types. For example, a
+CSS document, validated as such to the server's satisfaction, might still be
+crafted with malicious effects that are triggered if interperted as
+application/javascript.
+
+Servers SHOULD NOT rely on "integrity" to ensure the safe behavior of
+user-generated content stored on untrusted/third party servers, even if
+the document is sanity/validity checked.
+</section><!-- /Security::behavior -->
+
 </section><!-- /Security -->
 
 <section>


### PR DESCRIPTION
Remind people that a document, even with a successfully asserted hash, is still subject to multiple interpretations, including possibly malicious interpertations.