### PR TITLE
SRI: Allow non-eligible resources with empty integrity attributes

### DIFF
--- a/specs/subresourceintegrity/index.html
+++ b/specs/subresourceintegrity/index.html
@@ -542,11 +542,11 @@ result is <var>newAlgorithm</var>, set <var>strongest</var> to
 
       <ol>
         <li>If <var>resource</var>’s URL’s scheme is <code>about</code>, return <code>true</code>.</li>
-        <li>If <a href="#is-resource-eligible-for-integrity-validation"><var>resource</var> is not eligible for integrity
-validation</a>, return <code>false</code>.</li>
         <li>Let <var>parsedMetadata</var> be the result of
 <a href="#parse-metadata.x">parsing <var>metadataList</var></a>.</li>
         <li>If <var>parsedMetadata</var> is <code>no metadata</code>, return <code>true</code>.</li>
+        <li>If <a href="#is-resource-eligible-for-integrity-validation"><var>resource</var> is not eligible for integrity
+validation</a>, return <code>false</code>.</li>
         <li>Let <var>metadata</var> be the result of <a href="#get-the-strongest-metadata-from-set.x">getting the strongest
 metadata from <var>parsedMetadata</var></a>.</li>
         <li>For each <var>item</var> in <var>metadata</var>:

--- a/specs/subresourceintegrity/spec.markdown
+++ b/specs/subresourceintegrity/spec.markdown
@@ -409,11 +409,11 @@ the user agent.
 #### Does <var>resource</var> match <var>metadataList</var>?
 
 1.  If <var>resource</var>'s URL's scheme is `about`, return `true`.
-2.  If [<var>resource</var> is not eligible for integrity
-    validation][eligible], return `false`.
-3.  Let <var>parsedMetadata</var> be the result of
+2.  Let <var>parsedMetadata</var> be the result of
     [parsing <var>metadataList</var>][parse].
-4.  If <var>parsedMetadata</var> is `no metadata`, return `true`.
+3.  If <var>parsedMetadata</var> is `no metadata`, return `true`.
+4.  If [<var>resource</var> is not eligible for integrity
+    validation][eligible], return `false`.
 5.  Let <var>metadata</var> be the result of [getting the strongest
     metadata from <var>parsedMetadata</var>][get-the-strongest].
 6.  For each <var>item</var> in <var>metadata</var>:


### PR DESCRIPTION
Using the original steps, a resource with an empty integrity
attribute might be blocked if it's not eligible (e.g. non-CORS and
not same-origin). This is wrong since we're not supposed to do
any checks or block anything in the "no metadata" case.

With this change, empty integrity attributes will always pass the
checks and never be blocked for SRI reasons.