### PR TITLE
Specify that user agents must ignore unrecognized option-expressions

### DIFF
--- a/specs/subresourceintegrity/index.html
+++ b/specs/subresourceintegrity/index.html
@@ -699,6 +699,9 @@ hash-expression    = hash-algo "-" base64-value
     <p><code>option-expression</code>s are associated on a per <code>hash-expression</code> basis and are
 applied only to the <code>hash-expression</code> that immediately precedes it.</p>
 
+    <p>In order for user agents to remain fully forwards compatible with future
+options, the user agent MUST ignore all unrecognized  <code>option-expression</code>s</p>
+
   </section>
   <!-- /Framework::HTML::integrity -->
 

--- a/specs/subresourceintegrity/spec.markdown
+++ b/specs/subresourceintegrity/spec.markdown
@@ -552,6 +552,9 @@ The `integrity` IDL attribute must [reflect][] the `integrity` content attribute
 `option-expression`s are associated on a per `hash-expression` basis and are
 applied only to the `hash-expression` that immediately precedes it.
 
+In order for user agents to remain fully forwards compatible with future
+options, the user agent MUST ignore all unrecognized  `option-expression`s
+
 [reflect]: http://www.w3.org/TR/html5/infrastructure.html#reflect
 </section><!-- /Framework::HTML::integrity -->
 


### PR DESCRIPTION
This adds a requirement that user agents ignore unrecognized options-expressions for forwards compatibility reasons.