### PR TITLE
POWER: Combine "Should X require priv. context" w/ threat model

### DIFF
--- a/specs/powerfulfeatures/index.html
+++ b/specs/powerfulfeatures/index.html
@@ -70,8 +70,8 @@
   
    <h1 class="p-name no-ref" id="title">Privileged Contexts</h1>
   
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft
-    <time class="dt-updated" datetime="2015-04-24">24 April 2015</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft,
+    <time class="dt-updated" datetime="2015-05-06">6 May 2015</time></span></h2>
   
    <div data-fill-with="spec-metadata">
     <dl>
@@ -170,15 +170,16 @@ exposed to the web only within a trustworthy environment.</p>
    <ul class="toc" role="directory">
     <li><a href="#intro"><span class="secno">1</span> <span class="content">Introduction</span></a>
     <li><a href="#terms"><span class="secno">2</span> <span class="content">Key Concepts and Terminology</span></a>
-    <li><a href="#feature-requires-privilege"><span class="secno">3</span> <span class="content">
-    Should <var>[insert feature here]</var> require a privileged context?
+    <li><a href="#threat-models-risks"><span class="secno">3</span> <span class="content">
+      Threat models and risks
   </span></a>
      <ul class="toc">
       <li><a href="#threat-models"><span class="secno">3.1</span> <span class="content">Threat Models</span></a>
        <ul class="toc">
-        <li><a href="#thread-passive"><span class="secno">3.1.1</span> <span class="content">Passive Network Attacker</span></a>
+        <li><a href="#threat-passive"><span class="secno">3.1.1</span> <span class="content">Passive Network Attacker</span></a>
         <li><a href="#threat-active"><span class="secno">3.1.2</span> <span class="content">Active Network Attacker</span></a>
        </ul>
+      <li><a href="#threat-risks"><span class="secno">3.2</span> <span class="content">Risks associated with non-privileged contexts</span></a>
      </ul>
     <li><a href="#restrictions"><span class="secno">4</span> <span class="content">Restricting Features</span></a>
      <ul class="toc">
@@ -318,86 +319,12 @@ exposed to the web only within a trustworthy environment.</p>
 
    <section>
   
-    <h2 class="heading settled" data-level="3" id="feature-requires-privilege"><span class="secno">3. </span><span class="content">
-    Should <var>[insert feature here]</var> require a privileged context?
-  </span><a class="self-link" href="#feature-requires-privilege"></a></h2>
+    <h2 class="heading settled" data-level="3" id="threat-models-risks"><span class="secno">3. </span><span class="content">
+      Threat models and risks
+  </span><a class="self-link" href="#threat-models-risks"></a></h2>
 
 
     <p><em>This section is non-normative.</em></p>
-
-
-    <p>Certain web platform features that have a distinct impact on a user’s
-  security or privacy should be available for use only in <a data-link-type="dfn" href="#privileged-context">privileged
-  contexts</a>.</p>
-
-
-    <p>Broadly speaking, we consider a feature powerful enough to restrict when it
-  fits into one or more of the following categories:</p>
-
-  
-    <ol>
-    
-     <li>
-      The feature provides access to sensitive data (personally-identifying
-      information, credentials, payment instruments, and so on).
-      <a data-link-type="biblio" href="#biblio-credential-management">[CREDENTIAL-MANAGEMENT]</a> is an example of such an API.
-    
-     
-    
-     <li>
-      The feature provides access to sensor data on a user’s device (camera,
-      microphone, and GPS being particularly noteworthy, but certainly including
-      less obviously dangerous sensors like the accelerometer).
-      <a data-link-type="biblio" href="#biblio-geolocation-api">[GEOLOCATION-API]</a> and <a data-link-type="biblio" href="#biblio-mediacapture-streams">[MEDIACAPTURE-STREAMS]</a> are historical examples.
-    
-     
-    
-     <li>
-      The feature provides access to or information about other devices a user
-      has access to. <a data-link-type="biblio" href="#biblio-discovery">[DISCOVERY]</a> and <a data-link-type="biblio" href="#biblio-bluetooth">[BLUETOOTH]</a> are good examples.
-    
-     
-    
-     <li>
-      The feature exposes temporary or persistent identifiers, including
-      identifiers which reset themselves after some period of time
-      (e.g. <code class="idl"><a data-link-type="idl" href="http://www.w3.org/TR/html5/webstorage.html#the-sessionstorage-attribute">sessionStorage</a></code>), identifiers the user can manually reset
-      (e.g. <a data-link-type="biblio" href="#biblio-encrypted-media">[ENCRYPTED-MEDIA]</a>, Cookies <a data-link-type="biblio" href="#biblio-rfc6265">[RFC6265]</a>, and <a data-link-type="biblio" href="#biblio-indexeddb">[IndexedDB]</a>),
-      as well as identifying hardware features the user can’t easily reset.
-    
-     
-    
-     <li>
-      The feature introduces some state for an origin which persists across
-      browsing sessions. <a data-link-type="biblio" href="#biblio-service-workers">[SERVICE-WORKERS]</a> is a great example.
-    
-     
-    
-     <li>
-      The feature manipulates a user agent’s native UI in some way which
-      removes, obscures, or manipulates details relevant to a user’s
-      understanding of her context. <a data-link-type="biblio" href="#biblio-fullscreen">[FULLSCREEN]</a>, for instance.
-    
-     
-    
-     <li>
-      The feature introduces some functionality for which user permission will
-      be required.
-    
-     
-  
-    </ol>
-
-
-    <p>This list is non-exhaustive, but should give you a feel for the types of
-  features we should be concerned about when writing or implementing
-  specifications.</p>
-
-
-    <p class="note" role="note">Note: While restricting the feature itself to <a data-link-type="dfn" href="#privileged-context">privileged contexts</a> is
-  critical, we ought not forget that facilities that carry such information
-  (such as new network access mechanisms, or other generic functions with access
-  to network data) are equally sensitive.</p>
 
   
     <h3 class="heading settled" data-level="3.1" id="threat-models"><span class="secno">3.1. </span><span class="content">Threat Models</span><a class="self-link" href="#threat-models"></a></h3>
@@ -410,7 +337,7 @@ exposed to the web only within a trustworthy environment.</p>
   passive and active.</p>
 
   
-    <h4 class="heading settled" data-level="3.1.1" id="thread-passive"><span class="secno">3.1.1. </span><span class="content">Passive Network Attacker</span><a class="self-link" href="#thread-passive"></a></h4>
+    <h4 class="heading settled" data-level="3.1.1" id="threat-passive"><span class="secno">3.1.1. </span><span class="content">Passive Network Attacker</span><a class="self-link" href="#threat-passive"></a></h4>
 
 
     <p>A "Passive Network Attacker" is a party who is able to observe traffic
@@ -439,6 +366,82 @@ exposed to the web only within a trustworthy environment.</p>
   recent examples), to parties with direct intent to compromise security or
   privacy who are able to target individual users, organizations or even
   entire populations.</p>
+
+  
+    <h3 class="heading settled" data-level="3.2" id="threat-risks"><span class="secno">3.2. </span><span class="content">Risks associated with non-privileged contexts</span><a class="self-link" href="#threat-risks"></a></h3>
+
+
+    <p>Certain web platform features that have a distinct impact on a user’s
+  security or privacy should be available for use only in <a data-link-type="dfn" href="#privileged-context">privileged
+  contexts</a> in order to defend against the threats above. Features
+  available in non-privileged contexts risk exposing these capabilities to
+  network attackers:</p>
+
+  
+    <ol>
+    
+     <li>
+      The ability to read and modify sensitive data (personally-identifying
+      information, credentials, payment instruments, and so on).
+      <a data-link-type="biblio" href="#biblio-credential-management">[CREDENTIAL-MANAGEMENT]</a> is an example of an API that handles sensitive
+      data.
+    
+     
+    
+     <li>
+      The ability to read and modify input from sensors on a user’s device
+      (camera, microphone, and GPS being particularly noteworthy, but
+      certainly including less obviously dangerous sensors like the
+      accelerometer). <a data-link-type="biblio" href="#biblio-geolocation-api">[GEOLOCATION-API]</a> and <a data-link-type="biblio" href="#biblio-mediacapture-streams">[MEDIACAPTURE-STREAMS]</a> are
+      historical examples of features that use sensor input.
+    
+     
+    
+     <li>
+      The ability to access information about other devices a user
+      has access to. <a data-link-type="biblio" href="#biblio-discovery">[DISCOVERY]</a> and <a data-link-type="biblio" href="#biblio-bluetooth">[BLUETOOTH]</a> are good examples.
+    
+     
+    
+     <li>
+      The ability to track users using temporary or persistent identifiers,
+      including identifiers which reset themselves after some period of time
+      (e.g. <code class="idl"><a data-link-type="idl" href="http://www.w3.org/TR/html5/webstorage.html#the-sessionstorage-attribute">sessionStorage</a></code>), identifiers the user can manually reset
+      (e.g. <a data-link-type="biblio" href="#biblio-encrypted-media">[ENCRYPTED-MEDIA]</a>, Cookies <a data-link-type="biblio" href="#biblio-rfc6265">[RFC6265]</a>, and <a data-link-type="biblio" href="#biblio-indexeddb">[IndexedDB]</a>),
+      as well as identifying hardware features the user can’t easily reset.
+    
+     
+    
+     <li>
+      The ability to introduce some state for an origin which persists across
+      browsing sessions. <a data-link-type="biblio" href="#biblio-service-workers">[SERVICE-WORKERS]</a> is a great example.
+    
+     
+    
+     <li>
+      The ability to manipulate a user agent’s native UI in some way which
+      removes, obscures, or manipulates details relevant to a user’s
+      understanding of her context. <a data-link-type="biblio" href="#biblio-fullscreen">[FULLSCREEN]</a>, for instance.
+    
+     
+    
+     <li>
+      The ability to introduce some functionality for which user permission will
+      be required.
+    
+     
+  
+    </ol>
+
+
+    <p>This list is non-exhaustive, but should give you a feel for the types of
+  risks we should consider when writing or implementing specifications.</p>
+
+
+    <p class="note" role="note">Note: While restricting a feature itself to <a data-link-type="dfn" href="#privileged-context">privileged contexts</a> is
+  critical, we ought not forget that facilities that carry such information
+  (such as new network access mechanisms, or other generic functions with access
+  to network data) are equally sensitive.</p>
 </section>
 
 

--- a/specs/powerfulfeatures/index.src.html
+++ b/specs/powerfulfeatures/index.src.html
@@ -151,65 +151,11 @@ urlPrefix: https://tools.ietf.org/html/rfc6454; spec: RFC6454
 </section>
 
 <section>
-  <h2 id="feature-requires-privilege">
-    Should <var>[insert feature here]</var> require a privileged context?
+  <h2 id="threat-models-risks">
+      Threat models and risks
   </h2>
 
   <em>This section is non-normative.</em>
-
-  Certain web platform features that have a distinct impact on a user's
-  security or privacy should be available for use only in <a>privileged
-  contexts</a>.
-
-  Broadly speaking, we consider a feature powerful enough to restrict when it
-  fits into one or more of the following categories:
-
-  <ol>
-    <li>
-      The feature provides access to sensitive data (personally-identifying
-      information, credentials, payment instruments, and so on).
-      [[CREDENTIAL-MANAGEMENT]] is an example of such an API.
-    </li>
-    <li>
-      The feature provides access to sensor data on a user's device (camera,
-      microphone, and GPS being particularly noteworthy, but certainly including
-      less obviously dangerous sensors like the accelerometer).
-      [[GEOLOCATION-API]] and [[MEDIACAPTURE-STREAMS]] are historical examples.
-    </li>
-    <li>
-      The feature provides access to or information about other devices a user
-      has access to. [[DISCOVERY]] and [[BLUETOOTH]] are good examples.
-    </li>
-    <li>
-      The feature exposes temporary or persistent identifiers, including
-      identifiers which reset themselves after some period of time
-      (e.g. {{sessionStorage}}), identifiers the user can manually reset
-      (e.g. [[ENCRYPTED-MEDIA]], Cookies [[RFC6265]], and [[IndexedDB]]),
-      as well as identifying hardware features the user can't easily reset.
-    </li>
-    <li>
-      The feature introduces some state for an origin which persists across
-      browsing sessions. [[SERVICE-WORKERS]] is a great example.
-    </li>
-    <li>
-      The feature manipulates a user agent's native UI in some way which
-      removes, obscures, or manipulates details relevant to a user's
-      understanding of her context. [[FULLSCREEN]], for instance.
-    </li>
-    <li>
-      The feature introduces some functionality for which user permission will
-      be required.
-    </li>
-  </ol>
-
-  This list is non-exhaustive, but should give you a feel for the types of
-  features we should be concerned about when writing or implementing
-  specifications.
-
-  Note: While restricting the feature itself to <a>privileged contexts</a> is
-  critical, we ought not forget that facilities that carry such information
-  (such as new network access mechanisms, or other generic functions with access
-  to network data) are equally sensitive.
 
   <h3 id="threat-models">Threat Models</h3>
 
@@ -219,7 +165,7 @@ urlPrefix: https://tools.ietf.org/html/rfc6454; spec: RFC6454
   attacker is present. Generally, network attackers fall into 2 classes:
   passive and active.
 
-  <h4 id="thread-passive">Passive Network Attacker</h4>
+  <h4 id="threat-passive">Passive Network Attacker</h4>
 
   A "Passive Network Attacker" is a party who is able to observe traffic
   flows but who lacks the ability or chooses not to modify traffic at
@@ -244,6 +190,62 @@ urlPrefix: https://tools.ietf.org/html/rfc6454; spec: RFC6454
   recent examples), to parties with direct intent to compromise security or
   privacy who are able to target individual users, organizations or even
   entire populations.
+
+  <h3 id="threat-risks">Risks associated with non-privileged contexts</h3>
+
+  Certain web platform features that have a distinct impact on a user's
+  security or privacy should be available for use only in <a>privileged
+  contexts</a> in order to defend against the threats above. Features
+  available in non-privileged contexts risk exposing these capabilities to
+  network attackers:
+
+  <ol>
+    <li>
+      The ability to read and modify sensitive data (personally-identifying
+      information, credentials, payment instruments, and so on).
+      [[CREDENTIAL-MANAGEMENT]] is an example of an API that handles sensitive
+      data.
+    </li>
+    <li>
+      The ability to read and modify input from sensors on a user's device
+      (camera, microphone, and GPS being particularly noteworthy, but
+      certainly including less obviously dangerous sensors like the
+      accelerometer). [[GEOLOCATION-API]] and [[MEDIACAPTURE-STREAMS]] are
+      historical examples of features that use sensor input.
+    </li>
+    <li>
+      The ability to access information about other devices a user
+      has access to. [[DISCOVERY]] and [[BLUETOOTH]] are good examples.
+    </li>
+    <li>
+      The ability to track users using temporary or persistent identifiers,
+      including identifiers which reset themselves after some period of time
+      (e.g. {{sessionStorage}}), identifiers the user can manually reset
+      (e.g. [[ENCRYPTED-MEDIA]], Cookies [[RFC6265]], and [[IndexedDB]]),
+      as well as identifying hardware features the user can't easily reset.
+    </li>
+    <li>
+      The ability to introduce some state for an origin which persists across
+      browsing sessions. [[SERVICE-WORKERS]] is a great example.
+    </li>
+    <li>
+      The ability to manipulate a user agent's native UI in some way which
+      removes, obscures, or manipulates details relevant to a user's
+      understanding of her context. [[FULLSCREEN]], for instance.
+    </li>
+    <li>
+      The ability to introduce some functionality for which user permission will
+      be required.
+    </li>
+  </ol>
+
+  This list is non-exhaustive, but should give you a feel for the types of
+  risks we should consider when writing or implementing specifications.
+
+  Note: While restricting a feature itself to <a>privileged contexts</a> is
+  critical, we ought not forget that facilities that carry such information
+  (such as new network access mechanisms, or other generic functions with access
+  to network data) are equally sensitive.
 </section>
 
 <section>


### PR DESCRIPTION
Per discussion with @mikewest this morning, it seems that some of Mozilla's concerns raised in [this thread](https://lists.w3.org/Archives/Public/public-webappsec/2015Mar/0104.html) are addressed by reframing "Should X require a privileged context" in terms of the threat model.