### PR TITLE
Please rename while we can

### DIFF
--- a/specs/powerfulfeatures/index.html
+++ b/specs/powerfulfeatures/index.html
@@ -179,7 +179,7 @@ exposed to the web only within a trustworthy environment.</p>
         <li><a href="#threat-passive"><span class="secno">3.1.1</span> <span class="content">Passive Network Attacker</span></a>
         <li><a href="#threat-active"><span class="secno">3.1.2</span> <span class="content">Active Network Attacker</span></a>
        </ul>
-      <li><a href="#threat-risks"><span class="secno">3.2</span> <span class="content">Risks associated with non-secure contexts</span></a>
+      <li><a href="#threat-risks"><span class="secno">3.2</span> <span class="content">Risks associated with insecure contexts</span></a>
      </ul>
     <li><a href="#restrictions"><span class="secno">4</span> <span class="content">Restricting Features</span></a>
      <ul class="toc">
@@ -368,13 +368,13 @@ exposed to the web only within a trustworthy environment.</p>
   entire populations.</p>
 
   
-    <h3 class="heading settled" data-level="3.2" id="threat-risks"><span class="secno">3.2. </span><span class="content">Risks associated with non-secure contexts</span><a class="self-link" href="#threat-risks"></a></h3>
+    <h3 class="heading settled" data-level="3.2" id="threat-risks"><span class="secno">3.2. </span><span class="content">Risks associated with insecure contexts</span><a class="self-link" href="#threat-risks"></a></h3>
 
 
     <p>Certain web platform features that have a distinct impact on a user’s
   security or privacy should be available for use only in <a data-link-type="dfn" href="#secure-context">secure
   contexts</a> in order to defend against the threats above. Features
-  available in non-secure contexts risk exposing these capabilities to
+  available in insecure contexts risk exposing these capabilities to
   network attackers:</p>
 
   
@@ -553,7 +553,7 @@ exposed to the web only within a trustworthy environment.</p>
     
      <li>
       User agents should announce clear intentions to disable the API for
-      unsecure contexts on a specific date, and warn developers accordingly
+      insecure contexts on a specific date, and warn developers accordingly
       (via console messages, for example).
     
      

--- a/specs/powerfulfeatures/index.html
+++ b/specs/powerfulfeatures/index.html
@@ -5,7 +5,7 @@
   <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
   
   
-  <title>Privileged Contexts</title>
+  <title>Secure Contexts</title>
   
   
   <link href="../default.css" rel="stylesheet" type="text/css">
@@ -68,10 +68,10 @@
 </a>
 </p>
   
-   <h1 class="p-name no-ref" id="title">Privileged Contexts</h1>
+   <h1 class="p-name no-ref" id="title">Secure Contexts</h1>
   
    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft,
-    <time class="dt-updated" datetime="2015-05-06">6 May 2015</time></span></h2>
+    <time class="dt-updated" datetime="2015-05-07">7 May 2015</time></span></h2>
   
    <div data-fill-with="spec-metadata">
     <dl>
@@ -91,7 +91,7 @@
      <dd class="editor p-author h-card vcard" data-editor-id="56384"><a class="p-name fn u-email email" href="mailto:mkwst@google.com">Mike West</a> (<span class="p-org org">Google Inc.</span>)
      <dd class="editor p-author h-card vcard" data-editor-id="75060"><a class="p-name fn u-email email" href="mailto:yzhu@yahoo-inc.com">Yan Zhu</a> (<span class="p-org org">Yahoo! Inc.</span>)
      <dt>Bug Reports:
-     <dd><span><a href="https://github.com/w3c/webappsec/issues/new?title=PRIVILEGE:%20">via the w3c/webappsec repository on GitHub</a></span>
+     <dd><span><a href="https://github.com/w3c/webappsec/issues/new?title=SECURE:%20">via the w3c/webappsec repository on GitHub</a></span>
     </dl>
    </div>
   
@@ -179,7 +179,7 @@ exposed to the web only within a trustworthy environment.</p>
         <li><a href="#threat-passive"><span class="secno">3.1.1</span> <span class="content">Passive Network Attacker</span></a>
         <li><a href="#threat-active"><span class="secno">3.1.2</span> <span class="content">Active Network Attacker</span></a>
        </ul>
-      <li><a href="#threat-risks"><span class="secno">3.2</span> <span class="content">Risks associated with non-privileged contexts</span></a>
+      <li><a href="#threat-risks"><span class="secno">3.2</span> <span class="content">Risks associated with non-secure contexts</span></a>
      </ul>
     <li><a href="#restrictions"><span class="secno">4</span> <span class="content">Restricting Features</span></a>
      <ul class="toc">
@@ -191,8 +191,8 @@ exposed to the web only within a trustworthy environment.</p>
      </ul>
     <li><a href="#algorithms"><span class="secno">5</span> <span class="content">Algorithms</span></a>
      <ul class="toc">
-      <li><a href="#settings-privileged"><span class="secno">5.1</span> <span class="content">
-      Is <var>settings object</var> a privileged context?
+      <li><a href="#settings-secure"><span class="secno">5.1</span> <span class="content">
+      Is <var>settings object</var> a secure context?
     </span></a>
       <li><a href="#is-origin-trustworthy"><span class="secno">5.2</span> <span class="content">
       Is <var>origin</var> potentially trustworthy?
@@ -261,37 +261,37 @@ exposed to the web only within a trustworthy environment.</p>
   
     <dl>
     
-     <dt><dfn data-dfn-type="dfn" data-export="" id="privileged-context">
-      privileged context
-    <a class="self-link" href="#privileged-context"></a></dfn>
+     <dt><dfn data-dfn-type="dfn" data-export="" id="secure-context">
+      secure context
+    <a class="self-link" href="#secure-context"></a></dfn>
      
     
      <dd>
-      A <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#settings-object">settings object</a> is considered a <strong>privileged
-      context</strong> if the algorithm defined in <a href="#settings-privileged">§5.1 
-      Is settings object a privileged context?
+      A <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#settings-object">settings object</a> is considered a <strong>secure
+      context</strong> if the algorithm defined in <a href="#settings-secure">§5.1 
+      Is settings object a secure context?
     </a>
-      returns <code>Privileged</code> when executed upon it. Moreover:
+      returns <code>Secure</code> when executed upon it. Moreover:
 
       
       <ul>
         
        <li>
-          A <code class="idl"><a data-link-type="idl" href="http://www.w3.org/TR/dom/#interface-document">Document</a></code> is considered a <dfn data-dfn-type="dfn" data-export="" id="privileged-document">privileged document<a class="self-link" href="#privileged-document"></a></dfn>
-          if the algorithm defined in <a href="#settings-privileged">§5.1 
-      Is settings object a privileged context?
+          A <code class="idl"><a data-link-type="idl" href="http://www.w3.org/TR/dom/#interface-document">Document</a></code> is considered a <dfn data-dfn-type="dfn" data-export="" id="secure-document">secure document<a class="self-link" href="#secure-document"></a></dfn>
+          if the algorithm defined in <a href="#settings-secure">§5.1 
+      Is settings object a secure context?
     </a> returns
-          <code>Privileged</code> when executed upon its <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#incumbent-settings-object">incumbent settings
+          <code>Secure</code> when executed upon its <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#incumbent-settings-object">incumbent settings
           object</a>.
         
        
         
        <li>
           A <code class="idl"><a data-link-type="idl" href="http://www.w3.org/TR/workers/#worker">Worker</a></code>, <code class="idl"><a data-link-type="idl" href="http://www.w3.org/TR/workers/#sharedworker">SharedWorker</a></code>, or <code class="idl"><a data-link-type="idl" href="http://www.w3.org/TR/service-workers/#service-worker-obj">ServiceWorker</a></code> is considered a
-          <dfn data-dfn-type="dfn" data-export="" id="privileged-worker">privileged worker<a class="self-link" href="#privileged-worker"></a></dfn> if the algorithm defined in
-          <a href="#settings-privileged">§5.1 
-      Is settings object a privileged context?
-    </a> returns <code>Privileged</code> when executed
+          <dfn data-dfn-type="dfn" data-export="" id="secure-worker">secure worker<a class="self-link" href="#secure-worker"></a></dfn> if the algorithm defined in
+          <a href="#settings-secure">§5.1 
+      Is settings object a secure context?
+    </a> returns <code>Secure</code> when executed
           upon its <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#incumbent-settings-object">incumbent settings object</a>.
         
        
@@ -362,19 +362,19 @@ exposed to the web only within a trustworthy environment.</p>
   adversaries at many levels of capability, from compromised devices offering
   or simply participating in public wireless networks, to Internet Service
   Providers indirectly introducing security and privacy vulnerabilities while
-  manipulating traffic for financial gain (<a data-link-type="biblio" href="#biblio-verizon">[VERIZON]</a> and <a data-link-type="biblio" href="#biblio-comcast">[COMCAST]</a> are
+  manipulating traffic for financial gain (<span>[VERIZON]</span> and <span>[COMCAST]</span> are
   recent examples), to parties with direct intent to compromise security or
   privacy who are able to target individual users, organizations or even
   entire populations.</p>
 
   
-    <h3 class="heading settled" data-level="3.2" id="threat-risks"><span class="secno">3.2. </span><span class="content">Risks associated with non-privileged contexts</span><a class="self-link" href="#threat-risks"></a></h3>
+    <h3 class="heading settled" data-level="3.2" id="threat-risks"><span class="secno">3.2. </span><span class="content">Risks associated with non-secure contexts</span><a class="self-link" href="#threat-risks"></a></h3>
 
 
     <p>Certain web platform features that have a distinct impact on a user’s
-  security or privacy should be available for use only in <a data-link-type="dfn" href="#privileged-context">privileged
+  security or privacy should be available for use only in <a data-link-type="dfn" href="#secure-context">secure
   contexts</a> in order to defend against the threats above. Features
-  available in non-privileged contexts risk exposing these capabilities to
+  available in non-secure contexts risk exposing these capabilities to
   network attackers:</p>
 
   
@@ -383,7 +383,7 @@ exposed to the web only within a trustworthy environment.</p>
      <li>
       The ability to read and modify sensitive data (personally-identifying
       information, credentials, payment instruments, and so on).
-      <a data-link-type="biblio" href="#biblio-credential-management">[CREDENTIAL-MANAGEMENT]</a> is an example of an API that handles sensitive
+      <span>[CREDENTIAL-MANAGEMENT]</span> is an example of an API that handles sensitive
       data.
     
      
@@ -399,7 +399,7 @@ exposed to the web only within a trustworthy environment.</p>
     
      <li>
       The ability to access information about other devices a user
-      has access to. <a data-link-type="biblio" href="#biblio-discovery">[DISCOVERY]</a> and <a data-link-type="biblio" href="#biblio-bluetooth">[BLUETOOTH]</a> are good examples.
+      has access to. <span>[DISCOVERY]</span> and <span>[BLUETOOTH]</span> are good examples.
     
      
     
@@ -438,7 +438,7 @@ exposed to the web only within a trustworthy environment.</p>
   risks we should consider when writing or implementing specifications.</p>
 
 
-    <p class="note" role="note">Note: While restricting a feature itself to <a data-link-type="dfn" href="#privileged-context">privileged contexts</a> is
+    <p class="note" role="note">Note: While restricting a feature itself to <a data-link-type="dfn" href="#secure-context">secure contexts</a> is
   critical, we ought not forget that facilities that carry such information
   (such as new network access mechanisms, or other generic functions with access
   to network data) are equally sensitive.</p>
@@ -455,18 +455,18 @@ exposed to the web only within a trustworthy environment.</p>
 
     <p>When writing a specification for new features, we recommend that authors
   and editors guard sensitive APIs with checks against
-  <a href="#settings-privileged">§5.1 
-      Is settings object a privileged context?
+  <a href="#settings-secure">§5.1 
+      Is settings object a secure context?
     </a>. For example, something like the following
   would be a good approach:</p>
 
   
-    <div class="example" id="example-c817f858"><a class="self-link" href="#example-c817f858"></a>
+    <div class="example" id="example-8ce7bce2"><a class="self-link" href="#example-8ce7bce2"></a>
     
      <ol>
       
       <li>
-        If the <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#incumbent-settings-object">incumbent settings object</a> is not a <a data-link-type="dfn" href="#privileged-context">privileged
+        If the <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#incumbent-settings-object">incumbent settings object</a> is not a <a data-link-type="dfn" href="#secure-context">secure
         context</a>, then [<i>insert something appropriate here: perhaps you
         could reject a Promise with a <code>SecurityError</code>, call an error
         callback, deny a permission request, etc.</i>].
@@ -490,7 +490,7 @@ exposed to the web only within a trustworthy environment.</p>
 
     <p>The list above clearly includes some existing functionality that is currently
   available to the web over insecure channels. We recommend that such legacy
-  functionality begin requiring a <a data-link-type="dfn" href="#privileged-context">privileged context</a> as quickly as is
+  functionality begin requiring a <a data-link-type="dfn" href="#secure-context">secure context</a> as quickly as is
   reasonably possible.</p>
 
   
@@ -500,13 +500,13 @@ exposed to the web only within a trustworthy environment.</p>
       If such a feature is not widely implemented, we recommend that the
       specification be immediately
       <a data-link-type="dfn" href="http://www.w3.org/2014/Process-20140801/#rec-modify">modified</a> to include a restriction
-      to <a data-link-type="dfn" href="#privileged-context">privileged contexts</a>.
+      to <a data-link-type="dfn" href="#secure-context">secure contexts</a>.
     
      
     
      <li>
       If such a feature is widely implemented, but not yet in wide use, we
-      recommend that it be quickly restricted to <a data-link-type="dfn" href="#privileged-context">privileged contexts</a> by
+      recommend that it be quickly restricted to <a data-link-type="dfn" href="#secure-context">secure contexts</a> by
       adding a check as described in <a href="#new">§4.1 New Features</a> to existing implementations, and
       <a data-link-type="dfn" href="http://www.w3.org/2014/Process-20140801/#rec-modify">modifying the specification</a>
       accordingly.
@@ -538,13 +538,13 @@ exposed to the web only within a trustworthy environment.</p>
     
      <li>
       <a data-link-type="dfn" href="http://www.w3.org/2014/Process-20140801/#rec-modify">Modify</a> the specification to include
-      checks against [[#settings-privileged] before executing the algorithms for
+      checks against [[#settings-secure] before executing the algorithms for
       <code class="idl"><a data-link-type="idl" href="http://www.w3.org/TR/geolocation-API/#get-current-position">getCurrentPosition()</a></code> and <code class="idl"><a data-link-type="idl" href="http://www.w3.org/TR/geolocation-API/#watch-position">watchPosition()</a></code>.
 
 
-      <p>If <a href="#settings-privileged">§5.1 
-      Is settings object a privileged context?
-    </a> returns <code>Not Privileged</code>, then
+      <p>If <a href="#settings-secure">§5.1 
+      Is settings object a secure context?
+    </a> returns <code>Not Secure</code>, then
       the algorithms should be aborted, and the <var>errorCallback</var> invoked
       with a <code>code</code> of <code>PERMISSION_DENIED</code>.</p>
       
@@ -553,7 +553,7 @@ exposed to the web only within a trustworthy environment.</p>
     
      <li>
       User agents should announce clear intentions to disable the API for
-      unprivileged contexts on a specific date, and warn developers accordingly
+      unsecure contexts on a specific date, and warn developers accordingly
       (via console messages, for example).
     
      
@@ -600,15 +600,15 @@ exposed to the web only within a trustworthy environment.</p>
   
     <section>
     
-     <h3 class="heading settled" data-level="5.1" id="settings-privileged"><span class="secno">5.1. </span><span class="content">
-      Is <var>settings object</var> a privileged context?
-    </span><a class="self-link" href="#settings-privileged"></a></h3>
+     <h3 class="heading settled" data-level="5.1" id="settings-secure"><span class="secno">5.1. </span><span class="content">
+      Is <var>settings object</var> a secure context?
+    </span><a class="self-link" href="#settings-secure"></a></h3>
      
 
 
      <p>Given a <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#settings-object">settings object</a> <var>settings</var>, this algorithm returns
-    <code>Privileged</code> if the object represents a <a data-link-type="dfn" href="#privileged-context">privileged
-    context</a>, and <code>Not Privileged</code> otherwise.</p>
+    <code>Secure</code> if the object represents a <a data-link-type="dfn" href="#secure-context">secure
+    context</a>, and <code>Not Secure</code> otherwise.</p>
      
 
     
@@ -650,7 +650,7 @@ exposed to the web only within a trustworthy environment.</p>
       Is origin potentially trustworthy?
     </a> algorithm
             on <var>origin</var> is <strong>not</strong> <code>Potentially
-            Trustworthy</code>, return <code>Not Privileged</code>.
+            Trustworthy</code>, return <code>Not Secure</code>.
           
         
         
@@ -675,7 +675,7 @@ exposed to the web only within a trustworthy environment.</p>
        <p class="note" role="note">Note: If <var>settings</var> maps to a <code class="idl"><a data-link-type="idl" href="http://www.w3.org/TR/dom/#interface-document">Document</a></code> (either directly,
         or as the <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#responsible-document">responsible document</a> of a <code class="idl"><a data-link-type="idl" href="http://www.w3.org/TR/workers/#worker">Worker</a></code>), we’ll walk all
         the way up the document’s ancestor chain to verify that the whole chain
-        is privileged.</p>
+        is secure.</p>
        
 
         
@@ -723,7 +723,7 @@ exposed to the web only within a trustworthy environment.</p>
     </a>
                 algorithm on <var>origin</var> is <strong>not</strong>
                 <code>Potentially Trustworthy</code>, return
-                <code>Not Privileged</code>.
+                <code>Not Secure</code>.
               
           
             
@@ -738,7 +738,7 @@ exposed to the web only within a trustworthy environment.</p>
       
       
       <li>
-        Return <code>Privileged</code>
+        Return <code>Secure</code>
       
       
     
@@ -883,7 +883,7 @@ exposed to the web only within a trustworthy environment.</p>
 
 
     <p>This document is largely based on the Chrome Security team’s work on
-  <a data-link-type="biblio" href="#biblio-powerful-new-features">[POWERFUL-NEW-FEATURES]</a>. Chris Palmer, Ryan Sleevi, and David Dorwin have
+  <span>[POWERFUL-NEW-FEATURES]</span>. Chris Palmer, Ryan Sleevi, and David Dorwin have
   been particularly engaged. Anne van Kesteren and Henri Sivonen have also
   provided very helpful feedback.</p>
 </section>
@@ -964,9 +964,9 @@ exposed to the web only within a trustworthy environment.</p>
    <li>conformant server, <a href="#conformant-server">Unnumbered section</a>
    <li>conformant user agent, <a href="#conformant-user-agent">Unnumbered section</a>
    <li>embedding document, <a href="#embedding-document">2</a>
-   <li>privileged context, <a href="#privileged-context">2</a>
-   <li>privileged document, <a href="#privileged-document">2</a>
-   <li>privileged worker, <a href="#privileged-worker">2</a></ul>
+   <li>secure context, <a href="#secure-context">2</a>
+   <li>secure document, <a href="#secure-document">2</a>
+   <li>secure worker, <a href="#secure-worker">2</a></ul>
   <h3 class="no-num heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
   <ul class="indexlist">
    <li><a data-link-type="biblio" href="#biblio-dom">[dom]</a> defines the following terms:
@@ -1001,7 +1001,7 @@ exposed to the web only within a trustworthy environment.</p>
     <ul>
      <li><a href="https://w3c.github.io/webappsec/specs/mixedcontent/#potentially-secure-origin">potentially secure origin</a>
     </ul>
-   <li><a data-link-type="biblio" href="#biblio-rfc6454">[RFC6454]</a> defines the following terms:
+   <li><a data-link-type="biblio" href="#biblio-rfc6454">[rfc6454]</a> defines the following terms:
     <ul>
      <li><a href="https://tools.ietf.org/html/rfc6454#section-2.3">globally unique identifier</a>
      <li><a href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a>
@@ -1010,11 +1010,11 @@ exposed to the web only within a trustworthy environment.</p>
     <ul>
      <li><a href="http://www.w3.org/TR/service-workers/#service-worker-obj">ServiceWorker</a>
     </ul>
-   <li><a data-link-type="biblio" href="#biblio-url">[URL]</a> defines the following terms:
+   <li><a data-link-type="biblio" href="#biblio-url">[url]</a> defines the following terms:
     <ul>
      <li><a href="https://url.spec.whatwg.org/#concept-url-origin">origin of a url</a>
     </ul>
-   <li><a data-link-type="biblio" href="#biblio-w3c-process">[W3C-PROCESS]</a> defines the following terms:
+   <li><span>[W3C-PROCESS]</span> defines the following terms:
     <ul>
      <li><a href="http://www.w3.org/2014/Process-20140801/#rec-modify">modify a specification</a>
     </ul>
@@ -1027,57 +1027,43 @@ exposed to the web only within a trustworthy environment.</p>
   <h3 class="no-num heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
   <dl>
    <dt id="biblio-fetch"><a class="self-link" href="#biblio-fetch"></a>[FETCH]
-   <dd>Anne van Kesteren. <a href="https://fetch.spec.whatwg.org/">Fetch</a>. Living Standard. URL: <a href="https://fetch.spec.whatwg.org/">https://fetch.spec.whatwg.org/</a>
+   <dd>Anne van Kesteren. <a href="https://fetch.spec.whatwg.org/">Fetch Standard</a>. Living Standard. URL: <a href="https://fetch.spec.whatwg.org/">https://fetch.spec.whatwg.org/</a>
    <dt id="biblio-mix"><a class="self-link" href="#biblio-mix"></a>[MIX]
-   <dd>Mike West. <a href="https://w3c.github.io/webappsec/specs/mixedcontent/">Mixed Content</a>. LCWD. URL: <a href="https://w3c.github.io/webappsec/specs/mixedcontent/">https://w3c.github.io/webappsec/specs/mixedcontent/</a>
-   <dt id="biblio-rfc4632"><a class="self-link" href="#biblio-rfc4632"></a>[RFC4632]
-   <dd>Vince Fuller; Tony Li. <a href="http://www.ietf.org/rfc/rfc4632.txt">Classless Inter-domain Routing (CIDR): The Internet Address Assignment and Aggregation Plan</a>. RFC. URL: <a href="http://www.ietf.org/rfc/rfc4632.txt">http://www.ietf.org/rfc/rfc4632.txt</a>
-   <dt id="biblio-rfc6454"><a class="self-link" href="#biblio-rfc6454"></a>[RFC6454]
-   <dd>Adam Barth. <a href="http://www.ietf.org/rfc/rfc6454.txt">The Web Origin Concept</a>. RFC. URL: <a href="http://www.ietf.org/rfc/rfc6454.txt">http://www.ietf.org/rfc/rfc6454.txt</a>
-   <dt id="biblio-rfc6761"><a class="self-link" href="#biblio-rfc6761"></a>[RFC6761]
-   <dd>Stuart Cheshire; Marc Krochmal. <a href="http://www.ietf.org/rfc/rfc6761.txt">Special-Use Domain Names</a>. RFC. URL: <a href="http://www.ietf.org/rfc/rfc6761.txt">http://www.ietf.org/rfc/rfc6761.txt</a>
-   <dt id="biblio-url"><a class="self-link" href="#biblio-url"></a>[URL]
-   <dd>Anne van Kesteren. <a href="https://url.spec.whatwg.org/">URL</a>. Living Standard. URL: <a href="https://url.spec.whatwg.org/">https://url.spec.whatwg.org/</a>
-   <dt id="biblio-w3c-process"><a class="self-link" href="#biblio-w3c-process"></a>[W3C-PROCESS]
-   <dd>Charles McCathie Nevile. <a href="http://www.w3.org/2014/Process-20140801/">World Wide Web Consortium Process Document</a>. URL: <a href="http://www.w3.org/2014/Process-20140801/">http://www.w3.org/2014/Process-20140801/</a>
+   <dd>Mike West. <a href="http://www.w3.org/TR/mixed-content/">Mixed Content</a>. 17 March 2015. CR. URL: <a href="http://www.w3.org/TR/mixed-content/">http://www.w3.org/TR/mixed-content/</a>
    <dt id="biblio-dom"><a class="self-link" href="#biblio-dom"></a>[DOM]
-   <dd>Anne van Kesteren; et al. <a href="http://www.w3.org/TR/dom/">W3C DOM4</a>. 10 July 2014. LCWD. URL: <a href="http://www.w3.org/TR/dom/">http://www.w3.org/TR/dom/</a>
+   <dd>Anne van Kesteren; et al. <a href="http://www.w3.org/TR/dom/">W3C DOM4</a>. 28 April 2015. LCWD. URL: <a href="http://www.w3.org/TR/dom/">http://www.w3.org/TR/dom/</a>
    <dt id="biblio-geolocation-api"><a class="self-link" href="#biblio-geolocation-api"></a>[geolocation-API]
    <dd>Andrei Popescu. <a href="http://www.w3.org/TR/geolocation-API/">Geolocation API Specification</a>. 24 October 2013. REC. URL: <a href="http://www.w3.org/TR/geolocation-API/">http://www.w3.org/TR/geolocation-API/</a>
    <dt id="biblio-html5"><a class="self-link" href="#biblio-html5"></a>[HTML5]
-   <dd>Robin Berjon; et al. <a href="http://www.w3.org/TR/html5/">HTML5</a>. 28 October 2014. REC. URL: <a href="http://www.w3.org/TR/html5/">http://www.w3.org/TR/html5/</a>
+   <dd>Ian Hickson; et al. <a href="http://www.w3.org/TR/html5/">HTML5</a>. 28 October 2014. REC. URL: <a href="http://www.w3.org/TR/html5/">http://www.w3.org/TR/html5/</a>
    <dt id="biblio-rfc2119"><a class="self-link" href="#biblio-rfc2119"></a>[RFC2119]
-   <dd>S. Bradner. <a href="http://www.ietf.org/rfc/rfc2119.txt">Key words for use in RFCs to Indicate Requirement Levels</a>. March 1997. Best Current Practice. URL: <a href="http://www.ietf.org/rfc/rfc2119.txt">http://www.ietf.org/rfc/rfc2119.txt</a>
+   <dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
+   <dt id="biblio-rfc4632"><a class="self-link" href="#biblio-rfc4632"></a>[RFC4632]
+   <dd>V. Fuller; T. Li. <a href="https://tools.ietf.org/html/rfc4632">Classless Inter-domain Routing (CIDR): The Internet Address Assignment and Aggregation Plan</a>. August 2006. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc4632">https://tools.ietf.org/html/rfc4632</a>
+   <dt id="biblio-rfc6454"><a class="self-link" href="#biblio-rfc6454"></a>[RFC6454]
+   <dd>A. Barth. <a href="https://tools.ietf.org/html/rfc6454">The Web Origin Concept</a>. December 2011. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc6454">https://tools.ietf.org/html/rfc6454</a>
+   <dt id="biblio-rfc6761"><a class="self-link" href="#biblio-rfc6761"></a>[RFC6761]
+   <dd>S. Cheshire; M. Krochmal. <a href="https://tools.ietf.org/html/rfc6761">Special-Use Domain Names</a>. February 2013. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc6761">https://tools.ietf.org/html/rfc6761</a>
    <dt id="biblio-service-workers"><a class="self-link" href="#biblio-service-workers"></a>[SERVICE-WORKERS]
-   <dd>Alex Russell; Jungkee Song. <a href="http://www.w3.org/TR/service-workers/">Service Workers</a>. 8 May 2014. WD. URL: <a href="http://www.w3.org/TR/service-workers/">http://www.w3.org/TR/service-workers/</a>
+   <dd>Alex Russell; Jungkee Song; Jake Archibald. <a href="http://www.w3.org/TR/service-workers/">Service Workers</a>. 5 February 2015. WD. URL: <a href="http://www.w3.org/TR/service-workers/">http://www.w3.org/TR/service-workers/</a>
+   <dt id="biblio-url"><a class="self-link" href="#biblio-url"></a>[URL]
+   <dd>Anne van Kesteren; Sam Ruby. <a href="http://www.w3.org/TR/url-1/">URL</a>. 9 December 2014. WD. URL: <a href="http://www.w3.org/TR/url-1/">http://www.w3.org/TR/url-1/</a>
    <dt id="biblio-workers"><a class="self-link" href="#biblio-workers"></a>[WORKERS]
    <dd>Ian Hickson. <a href="http://www.w3.org/TR/workers/">Web Workers</a>. 1 May 2012. CR. URL: <a href="http://www.w3.org/TR/workers/">http://www.w3.org/TR/workers/</a></dl>
   <h3 class="no-num heading settled" id="informative"><span class="content">Informative References</span><a class="self-link" href="#informative"></a></h3>
   <dl>
-   <dt id="biblio-bluetooth"><a class="self-link" href="#biblio-bluetooth"></a>[BLUETOOTH]
-   <dd>Jeffrey Yasskin; Vincent Scheib. <a href="https://webbluetoothcg.github.io/web-bluetooth/">Web Bluetooth</a>. URL: <a href="https://webbluetoothcg.github.io/web-bluetooth/">https://webbluetoothcg.github.io/web-bluetooth/</a>
-   <dt id="biblio-comcast"><a class="self-link" href="#biblio-comcast"></a>[COMCAST]
-   <dd>David Kravets. <a href="http://arstechnica.com/tech-policy/2014/09/why-comcasts-javascript-ad-injections-threaten-security-net-neutrality/">Comcast Wi-Fi serving self-promotional ads via JavaScript injection</a>. URL: <a href="http://arstechnica.com/tech-policy/2014/09/why-comcasts-javascript-ad-injections-threaten-security-net-neutrality/">http://arstechnica.com/tech-policy/2014/09/why-comcasts-javascript-ad-injections-threaten-security-net-neutrality/</a>
-   <dt id="biblio-credential-management"><a class="self-link" href="#biblio-credential-management"></a>[CREDENTIAL-MANAGEMENT]
-   <dd>Mike West. <a href="https://w3c.github.io/webappsec/specs/credentialmanagement/">Credential Management</a>. ED. URL: <a href="https://w3c.github.io/webappsec/specs/credentialmanagement/">https://w3c.github.io/webappsec/specs/credentialmanagement/</a>
-   <dt id="biblio-discovery"><a class="self-link" href="#biblio-discovery"></a>[DISCOVERY]
-   <dd>Rich Tibbett. <a href="https://dvcs.w3.org/hg/dap/raw-file/tip/discovery-api/Overview.html">Network Service Discovery</a>. URL: <a href="https://dvcs.w3.org/hg/dap/raw-file/tip/discovery-api/Overview.html">https://dvcs.w3.org/hg/dap/raw-file/tip/discovery-api/Overview.html</a>
    <dt id="biblio-indexeddb"><a class="self-link" href="#biblio-indexeddb"></a>[IndexedDB]
-   <dd>Nikunj Mehta; et al. <a href="http://www.w3.org/TR/IndexedDB/">Indexed Database API</a>. 4 July 2013. CR. URL: <a href="http://www.w3.org/TR/IndexedDB/">http://www.w3.org/TR/IndexedDB/</a>
-   <dt id="biblio-powerful-new-features"><a class="self-link" href="#biblio-powerful-new-features"></a>[POWERFUL-NEW-FEATURES]
-   <dd>Chrome Security Team. <a href="https://www.chromium.org/Home/chromium-security/prefer-secure-origins-for-powerful-new-features">Prefer Secure Origins For Powerful New Features</a>. URL: <a href="https://www.chromium.org/Home/chromium-security/prefer-secure-origins-for-powerful-new-features">https://www.chromium.org/Home/chromium-security/prefer-secure-origins-for-powerful-new-features</a>
-   <dt id="biblio-rfc7258"><a class="self-link" href="#biblio-rfc7258"></a>[RFC7258]
-   <dd>Stephen Farrell; Hannes Tschofenig. <a href="http://www.ietf.org/rfc/rfc7258.txt">Pervasive Monitoring Is an Attack</a>. RFC. URL: <a href="http://www.ietf.org/rfc/rfc7258.txt">http://www.ietf.org/rfc/rfc7258.txt</a>
-   <dt id="biblio-verizon"><a class="self-link" href="#biblio-verizon"></a>[VERIZON]
-   <dd>Mark Bergen; Alex Kantrowitz. <a href="http://adage.com/article/digital/verizon-target-mobile-subscribers-ads/293356/">Verizon looks to target its mobile subscribers with ads</a>. URL: <a href="http://adage.com/article/digital/verizon-target-mobile-subscribers-ads/293356/">http://adage.com/article/digital/verizon-target-mobile-subscribers-ads/293356/</a>
+   <dd>Nikunj Mehta; et al. <a href="http://www.w3.org/TR/IndexedDB/">Indexed Database API</a>. 8 January 2015. REC. URL: <a href="http://www.w3.org/TR/IndexedDB/">http://www.w3.org/TR/IndexedDB/</a>
    <dt id="biblio-encrypted-media"><a class="self-link" href="#biblio-encrypted-media"></a>[ENCRYPTED-MEDIA]
-   <dd>David Dorwin; et al. <a href="http://www.w3.org/TR/encrypted-media/">Encrypted Media Extensions</a>. 28 August 2014. WD. URL: <a href="http://www.w3.org/TR/encrypted-media/">http://www.w3.org/TR/encrypted-media/</a>
+   <dd>David Dorwin; et al. <a href="http://www.w3.org/TR/encrypted-media/">Encrypted Media Extensions</a>. 31 March 2015. WD. URL: <a href="http://www.w3.org/TR/encrypted-media/">http://www.w3.org/TR/encrypted-media/</a>
    <dt id="biblio-fullscreen"><a class="self-link" href="#biblio-fullscreen"></a>[FULLSCREEN]
-   <dd>Anne van Kesteren; Tantek Çelik. <a href="http://www.w3.org/TR/fullscreen/">Fullscreen</a>. 3 July 2012. WD. URL: <a href="http://www.w3.org/TR/fullscreen/">http://www.w3.org/TR/fullscreen/</a>
+   <dd>Anne van Kesteren; Tantek Çelik. <a href="http://www.w3.org/TR/fullscreen/">Fullscreen</a>. 18 November 2014. NOTE. URL: <a href="http://www.w3.org/TR/fullscreen/">http://www.w3.org/TR/fullscreen/</a>
    <dt id="biblio-mediacapture-streams"><a class="self-link" href="#biblio-mediacapture-streams"></a>[MEDIACAPTURE-STREAMS]
-   <dd>Daniel Burnett; et al. <a href="http://www.w3.org/TR/mediacapture-streams/">Media Capture and Streams</a>. 3 September 2013. WD. URL: <a href="http://www.w3.org/TR/mediacapture-streams/">http://www.w3.org/TR/mediacapture-streams/</a>
+   <dd>Daniel Burnett; et al. <a href="http://www.w3.org/TR/mediacapture-streams/">Media Capture and Streams</a>. 14 April 2015. LCWD. URL: <a href="http://www.w3.org/TR/mediacapture-streams/">http://www.w3.org/TR/mediacapture-streams/</a>
    <dt id="biblio-rfc6265"><a class="self-link" href="#biblio-rfc6265"></a>[RFC6265]
-   <dd>A. Barth. <a href="http://www.ietf.org/rfc/rfc6265.txt">HTTP State Management Mechanism</a>. April 2011. Proposed Standard. URL: <a href="http://www.ietf.org/rfc/rfc6265.txt">http://www.ietf.org/rfc/rfc6265.txt</a></dl>
+   <dd>A. Barth. <a href="https://tools.ietf.org/html/rfc6265">HTTP State Management Mechanism</a>. April 2011. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc6265">https://tools.ietf.org/html/rfc6265</a>
+   <dt id="biblio-rfc7258"><a class="self-link" href="#biblio-rfc7258"></a>[RFC7258]
+   <dd>S. Farrell; H. Tschofenig. <a href="https://tools.ietf.org/html/rfc7258">Pervasive Monitoring Is an Attack</a>. May 2014. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc7258">https://tools.ietf.org/html/rfc7258</a></dl>
   <h2 class="no-num heading settled" id="issues-index"><span class="content">Issues Index</span><a class="self-link" href="#issues-index"></a></h2>
   <div style="counter-reset:issue">
    <div class="issue">"<a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#api-base-url">API base URL</a>" isn’t correct. We should use whatever

--- a/specs/powerfulfeatures/index.src.html
+++ b/specs/powerfulfeatures/index.src.html
@@ -1,4 +1,4 @@
-<h1>Privileged Contexts</h1>
+<h1>Secure Contexts</h1>
 <pre class="metadata">
 Status: ED
 ED: https://w3c.github.io/webappsec/specs/powerfulfeatures/
@@ -14,7 +14,7 @@ Abstract:
   authors for implementing features whose properties dictate that they be
   exposed to the web only within a trustworthy environment.
 Version History: https://github.com/w3c/webappsec/commits/master/specs/powerfulfeatures/index.src.html
-!Bug Reports: <a href="https://github.com/w3c/webappsec/issues/new?title=PRIVILEGE:%20">via the w3c/webappsec repository on GitHub</a>
+!Bug Reports: <a href="https://github.com/w3c/webappsec/issues/new?title=SECURE:%20">via the w3c/webappsec repository on GitHub</a>
 Indent: 2
 </pre>
 <pre class="anchors">
@@ -73,7 +73,7 @@ urlPrefix: http://www.w3.org/TR/workers/; spec: WORKERS
 urlPrefix: https://tools.ietf.org/html/rfc6454; spec: RFC6454
   type: dfn
     text: globally unique identifier; url: section-2.3
-    text: origin; url: section-3.2 
+    text: origin; url: section-3.2
 </pre>
 <!--
 ████ ██    ██ ████████ ████████   ███████
@@ -117,24 +117,24 @@ urlPrefix: https://tools.ietf.org/html/rfc6454; spec: RFC6454
 
   <dl>
     <dt><dfn export>
-      privileged context
+      secure context
     </dfn></dt>
     <dd>
-      A <a>settings object</a> is considered a <strong>privileged
-      context</strong> if the algorithm defined in [[#settings-privileged]]
-      returns <code>Privileged</code> when executed upon it. Moreover:
+      A <a>settings object</a> is considered a <strong>secure
+      context</strong> if the algorithm defined in [[#settings-secure]]
+      returns <code>Secure</code> when executed upon it. Moreover:
 
       <ul>
         <li>
-          A {{Document}} is considered a <dfn export>privileged document</dfn>
-          if the algorithm defined in [[#settings-privileged]] returns
-          <code>Privileged</code> when executed upon its <a>incumbent settings
+          A {{Document}} is considered a <dfn export>secure document</dfn>
+          if the algorithm defined in [[#settings-secure]] returns
+          <code>Secure</code> when executed upon its <a>incumbent settings
           object</a>.
         </li>
         <li>
           A {{Worker}}, {{SharedWorker}}, or {{ServiceWorker}} is considered a
-          <dfn export>privileged worker</dfn> if the algorithm defined in
-          [[#settings-privileged]] returns <code>Privileged</code> when executed
+          <dfn export>secure worker</dfn> if the algorithm defined in
+          [[#settings-secure]] returns <code>Secure</code> when executed
           upon its <a>incumbent settings object</a>.
         </li>
       </ul>
@@ -191,12 +191,12 @@ urlPrefix: https://tools.ietf.org/html/rfc6454; spec: RFC6454
   privacy who are able to target individual users, organizations or even
   entire populations.
 
-  <h3 id="threat-risks">Risks associated with non-privileged contexts</h3>
+  <h3 id="threat-risks">Risks associated with non-secure contexts</h3>
 
   Certain web platform features that have a distinct impact on a user's
-  security or privacy should be available for use only in <a>privileged
+  security or privacy should be available for use only in <a>secure
   contexts</a> in order to defend against the threats above. Features
-  available in non-privileged contexts risk exposing these capabilities to
+  available in non-secure contexts risk exposing these capabilities to
   network attackers:
 
   <ol>
@@ -242,7 +242,7 @@ urlPrefix: https://tools.ietf.org/html/rfc6454; spec: RFC6454
   This list is non-exhaustive, but should give you a feel for the types of
   risks we should consider when writing or implementing specifications.
 
-  Note: While restricting a feature itself to <a>privileged contexts</a> is
+  Note: While restricting a feature itself to <a>secure contexts</a> is
   critical, we ought not forget that facilities that carry such information
   (such as new network access mechanisms, or other generic functions with access
   to network data) are equally sensitive.
@@ -255,13 +255,13 @@ urlPrefix: https://tools.ietf.org/html/rfc6454; spec: RFC6454
 
   When writing a specification for new features, we recommend that authors
   and editors guard sensitive APIs with checks against
-  [[#settings-privileged]]. For example, something like the following
+  [[#settings-secure]]. For example, something like the following
   would be a good approach:
 
   <div class="example">
     <ol>
       <li>
-        If the <a>incumbent settings object</a> is not a <a>privileged
+        If the <a>incumbent settings object</a> is not a <a>secure
         context</a>, then [<i>insert something appropriate here: perhaps you
         could reject a Promise with a <code>SecurityError</code>, call an error
         callback, deny a permission request, etc.</i>].
@@ -277,7 +277,7 @@ urlPrefix: https://tools.ietf.org/html/rfc6454; spec: RFC6454
 
   The list above clearly includes some existing functionality that is currently
   available to the web over insecure channels. We recommend that such legacy
-  functionality begin requiring a <a>privileged context</a> as quickly as is
+  functionality begin requiring a <a>secure context</a> as quickly as is
   reasonably possible.
 
   <ol>
@@ -285,11 +285,11 @@ urlPrefix: https://tools.ietf.org/html/rfc6454; spec: RFC6454
       If such a feature is not widely implemented, we recommend that the
       specification be immediately
       <a lt="modify a specification">modified</a> to include a restriction
-      to <a>privileged contexts</a>.
+      to <a>secure contexts</a>.
     </li>
     <li>
       If such a feature is widely implemented, but not yet in wide use, we
-      recommend that it be quickly restricted to <a>privileged contexts</a> by
+      recommend that it be quickly restricted to <a>secure contexts</a> by
       adding a check as described in [[#new]] to existing implementations, and
       <a lt="modify a specification">modifying the specification</a>
       accordingly.
@@ -313,16 +313,16 @@ urlPrefix: https://tools.ietf.org/html/rfc6454; spec: RFC6454
   <ol>
     <li>
       <a lt="modify a specification">Modify</a> the specification to include
-      checks against [[#settings-privileged] before executing the algorithms for
+      checks against [[#settings-secure] before executing the algorithms for
       {{getCurrentPosition()}} and {{watchPosition()}}.
 
-      If [[#settings-privileged]] returns <code>Not Privileged</code>, then
+      If [[#settings-secure]] returns <code>Not Secure</code>, then
       the algorithms should be aborted, and the <var>errorCallback</var> invoked
       with a <code>code</code> of <code>PERMISSION_DENIED</code>.
     </li>
     <li>
       User agents should announce clear intentions to disable the API for
-      unprivileged contexts on a specific date, and warn developers accordingly
+      unsecure contexts on a specific date, and warn developers accordingly
       (via console messages, for example).
     </li>
     <li>
@@ -352,13 +352,13 @@ urlPrefix: https://tools.ietf.org/html/rfc6454; spec: RFC6454
   <h2 id="algorithms">Algorithms</h2>
 
   <section>
-    <h3 id="settings-privileged">
-      Is <var>settings object</var> a privileged context?
+    <h3 id="settings-secure">
+      Is <var>settings object</var> a secure context?
     </h3>
 
     Given a <a>settings object</a> <var>settings</var>, this algorithm returns
-    <code>Privileged</code> if the object represents a <a>privileged
-    context</a>, and <code>Not Privileged</code> otherwise.
+    <code>Secure</code> if the object represents a <a>secure
+    context</a>, and <code>Not Secure</code> otherwise.
 
     <ol>
       <li>
@@ -385,7 +385,7 @@ urlPrefix: https://tools.ietf.org/html/rfc6454; spec: RFC6454
           <li>
             If the result of executing the [[#is-origin-trustworthy]] algorithm
             on <var>origin</var> is <strong>not</strong> <code>Potentially
-            Trustworthy</code>, return <code>Not Privileged</code>.
+            Trustworthy</code>, return <code>Not Secure</code>.
           </li>
         </ol>
 
@@ -402,7 +402,7 @@ urlPrefix: https://tools.ietf.org/html/rfc6454; spec: RFC6454
         Note: If <var>settings</var> maps to a {{Document}} (either directly,
         or as the <a>responsible document</a> of a {{Worker}}), we'll walk all
         the way up the document's ancestor chain to verify that the whole chain
-        is privileged.
+        is secure.
 
         <ol>
           <li>
@@ -435,14 +435,14 @@ urlPrefix: https://tools.ietf.org/html/rfc6454; spec: RFC6454
                 If the result of executing the [[#is-origin-trustworthy]]
                 algorithm on <var>origin</var> is <strong>not</strong>
                 <code>Potentially Trustworthy</code>, return
-                <code>Not Privileged</code>.
+                <code>Not Secure</code>.
               </li>
             </ol>
           </li>
         </ol>
       </li>
       <li>
-        Return <code>Privileged</code>
+        Return <code>Secure</code>
       </li>
     </ol>
   </section>
@@ -531,7 +531,7 @@ urlPrefix: https://tools.ietf.org/html/rfc6454; spec: RFC6454
   In order to support developers who run staging servers on non-loopback hosts,
   user agents MAY allow users to configure specific sets of origins as
   trustworthy, even though [[#is-origin-trustworthy]] would normally return
-  <code>Not Trusted</code>. 
+  <code>Not Trusted</code>.
 </section>
 
 <!--

--- a/specs/powerfulfeatures/index.src.html
+++ b/specs/powerfulfeatures/index.src.html
@@ -191,12 +191,12 @@ urlPrefix: https://tools.ietf.org/html/rfc6454; spec: RFC6454
   privacy who are able to target individual users, organizations or even
   entire populations.
 
-  <h3 id="threat-risks">Risks associated with non-secure contexts</h3>
+  <h3 id="threat-risks">Risks associated with insecure contexts</h3>
 
   Certain web platform features that have a distinct impact on a user's
   security or privacy should be available for use only in <a>secure
   contexts</a> in order to defend against the threats above. Features
-  available in non-secure contexts risk exposing these capabilities to
+  available in insecure contexts risk exposing these capabilities to
   network attackers:
 
   <ol>
@@ -322,7 +322,7 @@ urlPrefix: https://tools.ietf.org/html/rfc6454; spec: RFC6454
     </li>
     <li>
       User agents should announce clear intentions to disable the API for
-      unsecure contexts on a specific date, and warn developers accordingly
+      insecure contexts on a specific date, and warn developers accordingly
       (via console messages, for example).
     </li>
     <li>


### PR DESCRIPTION
The rationale for Privileged was apparently OE, but OE is HTTP-only and
therefore insecure. Given that, we should name this secure contexts
since it’s a much simpler name and easy to comprehend by everyone.

See also #264.

(I don't get the same references with Bikeshed. Not sure what is up with that. So you probably want to apply the patch locally.)