### PR TITLE
Referrer policy specification text fixes

### DIFF
--- a/specs/referrer-policy/index.html
+++ b/specs/referrer-policy/index.html
@@ -1,16 +1,16 @@
 <!doctype html>
 <html lang="en">
  <head>
-  
+
   <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
-  
-  
+
+
   <title>Referrer Policy</title>
-  
-  
+
+
   <link href="../default.css" rel="stylesheet" type="text/css">
-  
-  
+
+
   <style>
   body {
     background: url("https://www.w3.org/StyleSheets/TR/logo-ED") top left no-repeat white;
@@ -53,26 +53,26 @@
     list-style: none;
   }
   </style>
-  
+
 
   <meta content="Bikeshed 1.0.0" name="generator">
  </head>
- 
+
 
  <body class="h-entry">
 
   <div class="head">
-  
+
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/">
     <img alt="W3C" height="48" src="https://www.w3.org/Icons/w3c_home" width="72">
 </a>
 </p>
-  
+
    <h1 class="p-name no-ref" id="title">Referrer Policy</h1>
-  
+
    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft,
     <time class="dt-updated" datetime="2015-03-03">3 March 2015</time></span></h2>
-  
+
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -90,12 +90,12 @@
      <dd class="editor p-author h-card vcard"><a class="p-name fn u-email email" href="mailto:mkwst@google.com">Mike West</a> (<span class="p-org org">Google Inc.</span>)
     </dl>
    </div>
-  
+
    <div data-fill-with="warning"></div>
-  
+
    <p class="copyright" data-fill-with="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2015 <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.
 </p>
-  
+
    <hr title="Separator for header">
 </div>
 
@@ -244,7 +244,7 @@
 
 
    <section>
-  
+
     <h2 class="heading settled" data-level="1" id="intro"><span class="secno">1. </span><span class="content">Introduction</span><a class="self-link" href="#intro"></a></h2>
 
 
@@ -257,7 +257,7 @@
   type, authors might wish to control the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header
   more directly for a number of reasons:</p>
 
-  
+
     <h3 class="heading settled" data-level="1.1" id="intro-privacy"><span class="secno">1.1. </span><span class="content">Privacy</span><a class="self-link" href="#intro-privacy"></a></h3>
 
 
@@ -272,7 +272,7 @@
   that the links originated from the social networking site but not reveal which
   specific user’s profile contained the links.</p>
 
-  
+
     <h3 class="heading settled" data-level="1.2" id="intro-security"><span class="secno">1.2. </span><span class="content">Security</span><a class="self-link" href="#intro-security"></a></h3>
 
 
@@ -285,7 +285,7 @@
   capability. Controlling the referrer can help prevent these capability URLs
   from leaking via referrer headers. <a data-link-type="biblio" href="#biblio-capability-urls">[CAPABILITY-URLS]</a></p>
 
-  
+
     <h3 class="heading settled" data-level="1.3" id="intro-trackback"><span class="secno">1.3. </span><span class="content">Trackback</span><a class="self-link" href="#intro-trackback"></a></h3>
 
 
@@ -297,17 +297,17 @@
 
 
    <section>
-  
+
     <h2 class="heading settled" data-level="2" id="terms"><span class="secno">2. </span><span class="content">Key Concepts and Terminology</span><a class="self-link" href="#terms"></a></h2>
 
-  
+
     <dl>
-    
+
      <dt>
       <dfn data-dfn-type="dfn" data-export="" data-local-lt="policy" id="referrer-policy">referrer policy<a class="self-link" href="#referrer-policy"></a></dfn>
-    
-     
-    
+
+
+
      <dd>
       A <strong>referrer policy</strong> is a property of a <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#settings-object">settings
       object</a> that defines the algorithm used to populate the
@@ -318,40 +318,40 @@
       <p>If no referrer policy is explicitly set for a <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#settings-object">settings object</a>,
       then the value of the property is <code>null</code>. Otherwise, the value
       is whatever has been explicitly set, as explained in the
-      <a href="#set-referrer-policy">§6.1 
+      <a href="#set-referrer-policy">§6.1
     Set environment’s referrer policy to policy
   </a> algorithm.</p>
-      
-    
-     
 
-    
+
+
+
+
      <dt><dfn data-dfn-type="dfn" data-local-lt="same-origin" data-noexport="" id="same_origin-request">same-origin request<a class="self-link" href="#same_origin-request"></a></dfn>
-     
-    
+
+
      <dd>
       A <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#request">Request</a></code> <var>request</var> is a <strong>same-origin request</strong>
       if <var>request</var>’s <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#concept-request-origin">origin</a></code> and the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a> of
       <var>request</var>’s <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#concept-request-url">url</a></code> are <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-5"><code>the same</code></a>.
-    
-     
 
-    
+
+
+
      <dt><dfn data-dfn-type="dfn" data-local-lt="cross-origin" data-noexport="" id="cross_origin-request">cross-origin request<a class="self-link" href="#cross_origin-request"></a></dfn>
-     
-    
+
+
      <dd>
       A <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#request">Request</a></code> is a <strong>cross-origin request</strong> if it is
       <em>not</em> <a data-link-type="dfn" href="#same_origin-request">same-origin</a>.
-    
-     
-  
+
+
+
     </dl>
 </section>
 
 
    <section>
-  
+
     <h2 class="heading settled" data-level="3" id="referrer-policy-states"><span class="secno">3. </span><span class="content">Referrer Policy States</span><a class="self-link" href="#referrer-policy-states"></a></h2>
 
 
@@ -371,7 +371,7 @@
   baseline policy for requests. This policy may be tightened for specific
   requests via mechanisms like the <code><a data-link-type="dfn" href="http://www.w3.org/TR/html5/links.html#link-type-noreferrer">noreferrer</a></code> link type.</p>
 
-  
+
     <h3 class="heading settled" data-level="3.1" id="referrer-policy-state-no-referrer"><span class="secno">3.1. </span><span class="content">No Referrer</span><a class="self-link" href="#referrer-policy-state-no-referrer"></a></h3>
 
 
@@ -380,7 +380,7 @@
   <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#settings-object">settings object</a> to any <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a>. The header will be omitted
   entirely.</p>
 
-  
+
     <div class="example">
     If a document at <code>https://example.com/page.html</code> sets a policy of
     <code>No Referrer</code>, then navigations to
@@ -388,7 +388,7 @@
     <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header.
   </div>
 
-  
+
     <h3 class="heading settled" data-level="3.2" id="referrer-policy-state-no-referrer-when-downgrade"><span class="secno">3.2. </span><span class="content">No Referrer When Downgrade</span><a class="self-link" href="#referrer-policy-state-no-referrer-when-downgrade"></a></h3>
 
 
@@ -403,7 +403,7 @@
   priori</em> insecure origins</a>, on the other hand, will contain no referrer
   information. A <code><a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2">Referer</a></code> HTTP header will not be sent.</p>
 
-  
+
     <div class="example">
     If a document at <code>https://example.com/page.html</code> sets a policy of
     <code>No Referrer When Downgrade</code>, then navigations to
@@ -416,14 +416,14 @@
      <p>Navigations from that same page to
     <code><strong>http</strong>://not.example.com/</code> would send no
     <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header.</p>
-     
-  
+
+
     </div>
 
 
     <p>This is a user agent’s default behavior, if no policy is otherwise specified.</p>
 
-  
+
     <h3 class="heading settled" data-level="3.3" id="referrer-policy-state-origin"><span class="secno">3.3. </span><span class="content">Origin Only</span><a class="self-link" href="#referrer-policy-state-origin"></a></h3>
 
 
@@ -445,7 +445,7 @@
     <p class="note" role="note">Note: The <code>Origin Only</code> policy causes the origin of HTTPS referrers
   to be sent over the network as part of unencrypted HTTP requests.</p>
 
-  
+
     <div class="example">
     If a document at <code>https://example.com/page.html</code> sets a policy of
     <code>Origin Only</code>, then navigations to any <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a> would send a
@@ -454,7 +454,7 @@
     origins</a>.
   </div>
 
-  
+
     <h3 class="heading settled" data-level="3.4" id="referrer-policy-state-origin-when-cross-origin"><span class="secno">3.4. </span><span class="content">Origin When Cross-Origin</span><a class="self-link" href="#referrer-policy-state-origin-when-cross-origin"></a></h3>
 
 
@@ -477,7 +477,7 @@
   HTTPS referrers to be sent over the network as part of unencrypted HTTP
   requests.</p>
 
-  
+
     <div class="example">
     If a document at <code>https://example.com/page.html</code> sets a policy of
     <code>Origin When Cross-Origin</code>, then navigations to any
@@ -490,11 +490,11 @@
     would send a <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header with a value of
     <code>https://example.com/</code>, even to <a data-link-type="dfn" href="https://w3c.github.io/webappsec/specs/mixedcontent/#a-priori-insecure-origin"><em>a priori</em> insecure
     origins</a>.</p>
-     
-  
+
+
     </div>
 
-  
+
     <h3 class="heading settled" data-level="3.5" id="referrer-policy-state-unsafe-url"><span class="secno">3.5. </span><span class="content">Unsafe URL</span><a class="self-link" href="#referrer-policy-state-unsafe-url"></a></h3>
 
 
@@ -503,7 +503,7 @@
   both <a data-link-type="dfn" href="#cross_origin-request">cross-origin requests</a> and <a data-link-type="dfn" href="#same_origin-request">same-origin requests</a> made from
   a particular <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#settings-object">settings object</a>.</p>
 
-  
+
     <div class="example">
     If a document at <code>https://example.com/sekrit.html</code> sets a policy
     of <code>Unsafe URL</code>, then navigations to
@@ -521,51 +521,51 @@
 
 
    <section>
-  
+
     <h2 class="heading settled" data-level="4" id="referrer-policy-delivery"><span class="secno">4. </span><span class="content">Referrer Policy Delivery</span><a class="self-link" href="#referrer-policy-delivery"></a></h2>
 
 
-    <p>A <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#settings-object">settings object</a>’s <a data-link-type="dfn" href="#referrer-policy">referrer policy</a> is deliveredin one of four
+    <p>A <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#settings-object">settings object</a>’s <a data-link-type="dfn" href="#referrer-policy">referrer policy</a> is delivered in one of four
   ways:</p>
 
-  
+
     <ul>
-    
+
      <li>
       Via the <code>referrer</code> Content Security Policy directive (defined
       in <a href="#directive-referrer">§4.1 Delivery via CSP</a>), delivered via the
       <a href="https://w3c.github.io/webappsec/specs/content-security-policy/#content-security-policy-header-field"><code>Content-Security-Policy</code></a>
       HTTP header. <a data-link-type="biblio" href="#biblio-csp2">[CSP2]</a>
-    
-     
-    
+
+
+
      <li>
       Via the <code>referrer</code> Content Security Policy directive (defined
       in <a href="#directive-referrer">§4.1 Delivery via CSP</a>), delivered via a
       <a href="https://w3c.github.io/webappsec/specs/content-security-policy/#delivery-html-meta-element"><code>&lt;meta></code> element</a>
       <a data-link-type="biblio" href="#biblio-csp2">[CSP2]</a>
-    
-     
-    
+
+
+
      <li>
       Via a <code><a data-link-type="element" href="http://www.w3.org/TR/html5/document-metadata.html#the-meta-element">meta</a></code> element with a <code><a data-link-type="element-attr" href="http://www.w3.org/TR/html5/document-metadata.html#attr-meta-name">name</a></code> of <code>referrer</code>.
-    
-     
-    
+
+
+
      <li>
       Via a <code>referrer</code> attribute on an <code><a data-link-type="element" href="http://www.w3.org/TR/html5/text-level-semantics.html#the-a-element">a</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/#the-area-element">area</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/#the-img-element">img</a></code>
       or <code><a data-link-type="element" href="http://www.w3.org/TR/html5/embedded-content-0.html#the-iframe-element">iframe</a></code> element.
-    
-     
-    
+
+
+
      <li>
       Implicitly, via inheritance.
-    
-     
-  
+
+
+
     </ul>
 
-  
+
     <h3 class="heading settled" data-level="4.1" id="directive-referrer"><span class="secno">4.1. </span><span class="content">Delivery via CSP</span><a class="self-link" href="#directive-referrer"></a></h3>
 
 
@@ -576,7 +576,7 @@
   The syntax for the name and value of the directive are described by the
   following ABNF grammar:</p>
 
-  
+
     <pre>directive-name    = "referrer"
 directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "origin-when-cross-origin" / "unsafe-url"
 </pre>
@@ -588,43 +588,43 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
     <p>When
   <a href="https://w3c.github.io/webappsec/specs/content-security-policy/#enforce">enforcing</a>
   the <code>referrer</code> directive, the user agent MUST execute
-  <a href="#set-referrer-policy">§6.1 
+  <a href="#set-referrer-policy">§6.1
     Set environment’s referrer policy to policy
   </a> on the protected resource’s <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#incumbent-settings-object">incumbent settings
-  object</a>, using the result of executing <a href="#determine-policy-for-token">§6.4 
+  object</a>, using the result of executing <a href="#determine-policy-for-token">§6.4
     Determine token’s Policy
   </a>
   on the <code>referrer</code> directive’s value.</p>
 
-  
+
     <section class="informative">
-    
+
      <h4 class="heading settled" data-level="4.1.1" id="referrer-usage"><span class="secno">4.1.1. </span><span class="content">Usage</span><a class="self-link" href="#referrer-usage"></a></h4>
-     
+
 
 
      <p><em>This section is not normative.</em></p>
-     
+
 
 
      <p>A protected resource can prevent referrer leakage by specifying
     <code>no-referrer</code> as the value of its policy’s
     <code>referrer</code> directive:</p>
-     
 
-    
+
+
      <pre>Content-Security-Policy: referrer no-referrer;
 </pre>
-     
+
 
 
      <p>This will cause all requests made from the protected resource’s
     context to have an empty <code>Referer</code> [sic] header.</p>
-     
-  
+
+
     </section>
 
-  
+
     <h3 class="heading settled" data-level="4.2" id="referrer-policy-delivery-meta"><span class="secno">4.2. </span><span class="content">Delivery via <code><a data-link-type="element" href="http://www.w3.org/TR/html5/document-metadata.html#the-meta-element">meta</a></code></span><a class="self-link" href="#referrer-policy-delivery-meta"></a></h3>
 
 
@@ -633,7 +633,7 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
   for the string "<code>Referrer</code>" is inserted into a document, for
   example:</p>
 
-  
+
     <pre class="example">&lt;meta name="referrer" content="origin">
 </pre>
 
@@ -641,39 +641,39 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
     <p>The following values for the <code>content</code> attribute are valid, and map
   to the listed <a data-link-type="dfn" href="#referrer-policy">referrer policy</a> values:</p>
 
-  
+
     <dl>
-    
+
      <dt>no-referrer
-     
-    
+
+
      <dd><a data-link-type="dfn" href="#no-referrer"><code>No Referrer</code></a>
-     
-    
+
+
      <dt>origin
-     
-    
+
+
      <dd><a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2"><code>Origin</code></a>
-     
-    
+
+
      <dt>no-referrer-when-downgrade
-     
-    
+
+
      <dd><a data-link-type="dfn" href="#no-referrer-when-downgrade"><code>No Referrer When Downgrade</code></a>
-     
-    
+
+
      <dt>origin-when-crossorigin
-     
-    
+
+
      <dd><a data-link-type="dfn" href="#origin-when-cross_origin"><code>Origin When Cross-Origin</code></a>
-     
-    
+
+
      <dt>unsafe-url
-     
-    
+
+
      <dd><a data-link-type="dfn" href="#unsafe-url"><code>Unsafe URL</code></a>
-     
-  
+
+
     </dl>
 
 
@@ -681,75 +681,75 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
   <a href="http://www.w3.org/TR/html5/document-metadata.html#pragma-directives">pragma directives</a>
   for the <code><a data-link-type="element" href="http://www.w3.org/TR/html5/document-metadata.html#the-meta-element">meta</a></code> element:</p>
 
-  
+
     <dl>
-    
+
      <dt>
       Referrer policy
       (<code>name="Referrer"</code>)
-    
-     
-    
+
+
+
      <dd>
-      
+
       <ol>
-        
+
        <li>
           If the Document’s <code><a data-link-type="element" href="https://html.spec.whatwg.org/#the-head-element">head</a></code> element is not an ancestor of the <code><a data-link-type="element" href="http://www.w3.org/TR/html5/document-metadata.html#the-meta-element">meta</a></code>
           element, abort these steps.
-        
-       
 
-        
+
+
+
        <li>
           If the <code><a data-link-type="element" href="http://www.w3.org/TR/html5/document-metadata.html#the-meta-element">meta</a></code> element lacks a <code><a data-link-type="element-attr" href="http://www.w3.org/TR/html5/document-metadata.html#attr-meta-content">content</a></code> attribute then abort
           these steps.
-        
-       
 
-        
+
+
+
        <li>
           Let <var>environment</var> be the <code class="idl"><a data-link-type="idl" href="http://www.w3.org/TR/dom/#interface-document">Document</a></code>'s <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#incumbent-settings-object">incumbent settings
           object</a>.
-        
-       
 
-        
+
+
+
        <li>
           Let <var>meta-value</var> be the value of the element’s
           <code><a data-link-type="element-attr" href="http://www.w3.org/TR/html5/document-metadata.html#attr-meta-content">content</a></code> attribute, after
           <a data-link-type="dfn" href="http://www.w3.org/TR/html5/infrastructure.html#strip-leading-and-trailing-whitespace">stripping
           leading and trailing whitespace</a>.
-        
-       
 
-        
+
+
+
        <li>
           If <var>meta-value</var> is the empty string, then abort these steps.
-        
-       
 
-        
+
+
+
        <li>
           Let <var>policy</var> be the result of executing the
-          <a href="#determine-policy-for-token">§6.4 
+          <a href="#determine-policy-for-token">§6.4
     Determine token’s Policy
   </a> algorithm on <var>meta-value</var>.
-        
-       
 
-        
+
+
+
        <li>
-          Execute the <a href="#set-referrer-policy">§6.1 
+          Execute the <a href="#set-referrer-policy">§6.1
     Set environment’s referrer policy to policy
   </a> algorithm on
           <var>environment</var> using <var>policy</var>, if <var>policy</var>
           is not <code>null</code>.
-        
-       
-      
+
+
+
       </ol>
-      
+
 
 
       <p class="note" role="note">Note: Authors are encouraged to avoid the legacy keywords
@@ -757,19 +757,19 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
       keywords <code>no-referrer</code>,
       <code>no-referrer-when-downgrade</code>, and <code>unsafe-url</code>
       respectively are preferred.</p>
-      
+
 
 
       <p class="note" role="note">Note: Implementors are advised to also respect a <a data-link-type="dfn" href="#referrer-policy">referrer policy</a>
       delivered via a <code><a data-link-type="element" href="http://www.w3.org/TR/html5/document-metadata.html#the-meta-element">meta</a></code> element during
       speculative resource loads.</p>
-      
-    
-     
-  
+
+
+
+
     </dl>
 
-  
+
     <h3 class="heading settled" data-level="4.3" id="referrer-policy-delivery-referrer-attribute"><span class="secno">4.3. </span><span class="content">Delivery
   via a <code>referrer</code> attribute</span><a class="self-link" href="#referrer-policy-delivery-referrer-attribute"></a></h3>
 
@@ -779,7 +779,7 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
   <code><a data-link-type="element" href="https://html.spec.whatwg.org/#the-img-element">img</a></code> or <code><a data-link-type="element" href="http://www.w3.org/TR/html5/embedded-content-0.html#the-iframe-element">iframe</a></code>
   element, for example:</p>
 
-  
+
     <pre class="example">&lt;a href="http://example.com" referrer="origin">
 </pre>
 
@@ -787,27 +787,27 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
     <p>The following values for the <code>referrer</code> attribute are valid,
   and map to the listed <a data-link-type="dfn" href="#referrer-policy">referrer policy</a> values:</p>
 
-  
+
     <dl>
-    
+
      <dt>no-referrer
-     
-    
+
+
      <dd><a data-link-type="dfn" href="#no-referrer"><code>No Referrer</code></a>
-     
-    
+
+
      <dt>origin
-     
-    
+
+
      <dd><a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2"><code>Origin</code></a>
-     
-    
+
+
      <dt>unsafe-url
-     
-    
+
+
      <dd><a data-link-type="dfn" href="#unsafe-url"><code>Unsafe URL</code></a>
-     
-  
+
+
     </dl>
 
 
@@ -827,14 +827,14 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
   by <a href="https://lists.w3.org/Archives/Public/public-webappsec/2015Feb/0283.html">Brian
   Smith</a> and honor the <code>noreferrer</code> link type?</p>
 
-  
+
     <h3 class="heading settled" data-level="4.4" id="referrer-policy-delivery-implicit"><span class="secno">4.4. </span><span class="content">Implicit Delivery</span><a class="self-link" href="#referrer-policy-delivery-implicit"></a></h3>
 
 
     <p>A <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#settings-object">settings object</a> inherits the <a data-link-type="dfn" href="#referrer-policy">referrer policy</a> of another object
   in several circumstances:</p>
 
-  
+
     <h4 class="heading settled" data-level="4.4.1" id="referrer-policy-delivery-implicit-nested"><span class="secno">4.4.1. </span><span class="content">
      Nested Browsing Contexts
   </span><a class="self-link" href="#referrer-policy-delivery-implicit-nested"></a></h4>
@@ -845,33 +845,33 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
   is a <a data-link-type="dfn" href="http://www.w3.org/TR/url/#local-scheme">local scheme</a> (for instance, a <code>blob</code> or
   <code>data</code> resource):</p>
 
-  
+
     <ol>
-    
+
      <li>
       Let <var>environment</var> be the <a data-link-type="dfn" href="http://www.w3.org/TR/html5/browsers.html#nested-browsing-context">nested browsing context</a>’s
       <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#incumbent-settings-object">incumbent settings object</a>.
-    
-     
-    
+
+
+
      <li>
       Let <var>policy</var> be the <a data-link-type="dfn" href="http://www.w3.org/TR/html5/browsers.html#parent-browsing-context">parent browsing context</a>’s
       <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#incumbent-settings-object">incumbent settings object</a>’s <a data-link-type="dfn" href="#referrer-policy">referrer policy</a>.
-    
-     
-    
+
+
+
      <li>
-      Execute the <a href="#set-referrer-policy">§6.1 
+      Execute the <a href="#set-referrer-policy">§6.1
     Set environment’s referrer policy to policy
   </a> algorithm on
       <var>environment</var> using <var>policy</var>, if <var>policy</var>
       is not <code>null</code>.
-    
-     
-  
+
+
+
     </ol>
 
-  
+
     <h4 class="heading settled" data-level="4.4.2" id="referrer-policy-delivery-implicit-workers"><span class="secno">4.4.2. </span><span class="content">
     Workers
   </span><a class="self-link" href="#referrer-policy-delivery-implicit-workers"></a></h4>
@@ -880,34 +880,34 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
     <p>Whenever a user agent <a data-link-type="dfn" href="http://www.w3.org/TR/workers/#run-a-worker">runs a worker</a> for a script with <code class="idl"><a data-link-type="idl" href="http://www.w3.org/TR/url/#url">URL</a></code>
   <var>url</var> and <var>url</var>’s scheme is a <a data-link-type="dfn" href="http://www.w3.org/TR/url/#local-scheme">local scheme</a>:</p>
 
-  
+
     <ol>
-    
+
      <li>
       Let <var>environment</var> be the Worker’s <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#incumbent-settings-object">incumbent settings
       object</a>.
-    
-     
-    
+
+
+
      <li>
       Let <var>policy</var> be <code>No Referrer When Downgrade</code>.
-    
-     
-    
+
+
+
      <li>
-      Execute the <a href="#set-referrer-policy">§6.1 
+      Execute the <a href="#set-referrer-policy">§6.1
     Set environment’s referrer policy to policy
   </a> algorithm on
       <var>environment</var> using <var>policy</var>.
-    
-     
-  
+
+
+
     </ol>
 </section>
 
 
    <section>
-  
+
     <h2 class="heading settled" data-level="5" id="integration-with-fetch"><span class="secno">5. </span><span class="content">Integration with Fetch</span><a class="self-link" href="#integration-with-fetch"></a></h2>
 
 
@@ -923,10 +923,10 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
 
 
    <section>
-  
+
     <h2 class="heading settled" data-level="6" id="algorithms"><span class="secno">6. </span><span class="content">Algorithms</span><a class="self-link" href="#algorithms"></a></h2>
 
-  
+
     <h3 class="heading settled" data-level="6.1" id="set-referrer-policy"><span class="secno">6.1. </span><span class="content">
     Set <var>environment</var>’s referrer policy to <var>policy</var>
   </span><a class="self-link" href="#set-referrer-policy"></a></h3>
@@ -936,28 +936,28 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
   setting its value is straightforward. If a policy has previously been set,
   then we overwrite it with the new value.</p>
 
-  
+
     <ol>
-    
+
      <li>
       If <var>policy</var> is not one of <code><a data-link-type="dfn" href="#no-referrer">No Referrer</a></code>,
       <code><a data-link-type="dfn" href="#no-referrer-when-downgrade">No Referrer When Downgrade</a></code>, <code><a data-link-type="dfn" href="#origin-only">Origin
       Only</a></code>, <code><a data-link-type="dfn" href="#origin-when-cross_origin">Origin when cross-origin</a></code>, or
       <code><a data-link-type="dfn" href="#unsafe-url">Unsafe URL</a></code>, then return without setting
       <var>environment</var>’s referrer policy.
-    
-     
 
-    
+
+
+
      <li>
       Set <var>environment</var>’s <a data-link-type="dfn" href="#referrer-policy">referrer policy</a> to
       <var>policy</var>.
-    
-     
-  
+
+
+
     </ol>
 
-  
+
     <h3 class="heading settled" data-level="6.2" id="determine-requests-referrer"><span class="secno">6.2. </span><span class="content">
     Determine <var>request</var>’s Referrer
   </span><a class="self-link" href="#determine-requests-referrer"></a></h3>
@@ -978,213 +978,213 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
     <p class="issue" id="issue-2cf94c0c"><a class="self-link" href="#issue-2cf94c0c"></a>This algorithm needs to be modifed to take into account any local
   overrides via the referrer attribute on elements.</p>
 
-  
+
     <ol>
-    
+
      <li>
       Let <var>environment</var> be <var>request</var>’s <code>client</code>.
-    
-     
-    
+
+
+
      <li>
       Let <var>policy</var> be the value of <var>environment</var>’s
       <a data-link-type="dfn" href="#referrer-policy">referrer policy</a>.
-    
-     
-    
+
+
+
      <li>
       If <var>request</var>’s <code>referrer</code> is a URL, then let
       <var>referrerSource</var> be <var>request</var>’s
       <code>referrer</code>. Otherwise:
 
-      
+
       <ol>
-        
+
        <li>
           If <var>environment</var> is a <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#document-environment">document environment</a>:
 
-          
+
         <ol>
-            
+
          <li>
               Let <var>document</var> be the <code class="idl"><a data-link-type="idl" href="http://www.w3.org/TR/dom/#interface-document">Document</a></code> object of the
               <a data-link-type="dfn" href="http://www.w3.org/TR/html5/browsers.html#active-document">active document</a> of the <a data-link-type="dfn" href="http://www.w3.org/TR/html5/browsers.html#browsing-context">browsing context</a> of
               <var>environment</var>’s <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#responsible-browsing-context">responsible browsing context</a>.
-            
-         
-          
+
+
+
         </ol>
-        
-        
-       
-        
+
+
+
+
        <li>
           Otherwise, <var>environment</var> is a <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#worker-environment">worker environment</a>:
 
-          
+
         <ol>
-            
+
          <li>
               Let <var>source</var> be the <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#api-referrer-source">API referrer source</a>
               specified by the <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#incumbent-settings-object">incumbent settings object</a>.
-            
-         
-            
+
+
+
          <li>
               If <var>source</var> is a URL, let <var>referrerSource</var>
               be <var>source</var>, otherwise let <var>document</var> be
               <var>source</var>.
-            
-         
-          
+
+
+
         </ol>
-        
-        
-       
-        
+
+
+
+
        <li>
           If <var>document</var> is set, execute the following steps:
 
-          
+
         <ol>
-            
+
          <li>
               If <var>document</var>’s <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a> is not a scheme/host/port
               tuple (because, for example, it has been sandboxed into a unique
               origin), return <code>no referrer</code> and abort these steps.
-            
-         
-            
+
+
+
          <li>
               While <var>document</var> corresponds to <a data-link-type="dfn" href="http://www.w3.org/TR/html5/embedded-content-0.html#an-iframe-srcdoc-document">an iframe srcdoc Document</a>,
               let <var>document</var> be that Document’s <a data-link-type="dfn" href="http://www.w3.org/TR/html5/browsers.html#browsing-context">browsing context</a>’s
               <a data-link-type="dfn" href="http://www.w3.org/TR/html5/browsers.html#browsing-context-container">browsing context container</a>’s <code class="idl"><a data-link-type="idl" href="http://www.w3.org/TR/dom/#interface-document">Document</a></code>.
-            
-         
-            
+
+
+
          <li>
               Let <var>referrerSource</var> be <var>document</var>’s URL.
-            
-         
-          
+
+
+
         </ol>
-        
-        
-       
-      
+
+
+
+
       </ol>
-      
-    
-     
-    
+
+
+
+
      <li>
       Let <var>referrerURL</var> be the result of <a href="#strip-url">stripping
       <var>referrerSource</var> for use as a referrer.</a>
-    
-     
-    
+
+
+
      <li>
       Let <var>referrerOrigin</var> be the result of
       <a href="#strip-url">stripping <var>referrerSource</var> for use as a
       referrer</a>, with the <code><a data-link-type="dfn" href="#origin_only-flag">origin-only flag</a></code> set to
       <code>true</code>.
-    
-     
 
-    
+
+
+
      <li>
       Execute the statements corresponding to the value of <var>policy</var>:
 
-      
+
       <dl>
-        
+
        <dt><var>policy</var> is <code><a data-link-type="dfn" href="#no-referrer">No Referrer</a></code>
-       
-        
+
+
        <dd>Return <code>no referrer</code>
-       
 
-        
+
+
        <dt><var>policy</var> is <code><a data-link-type="dfn" href="#origin-only">Origin Only</a></code>
-       
-        
+
+
        <dd>Return <var>referrerOrigin</var>
-       
 
-        
+
+
        <dt><var>policy</var> is <code><a data-link-type="dfn" href="#unsafe-url">Unsafe URL</a></code>
-       
-        
-       <dd>Return <var>referrerURL</var>.
-       
 
-        
+
+       <dd>Return <var>referrerURL</var>.
+
+
+
        <dt>
           <var>policy</var> is <code><a data-link-type="dfn" href="#origin-when-cross_origin">Origin When Cross-Origin</a></code>
-        
-       
-        
+
+
+
        <dd>
-          
+
         <ol>
-            
+
          <li>
               If <var>request</var> is a <a data-link-type="dfn" href="#cross_origin-request">cross-origin request</a>, then
               return <var>referrerOrigin</var>.
-            
-         
-            
+
+
+
          <li>
               Otherwise, return <var>referrerURL</var>.
-            
-         
-          
-        </ol>
-        
-        
-       
 
-        
+
+
+        </ol>
+
+
+
+
+
        <dt>
           <var>policy</var> is <code><a data-link-type="dfn" href="#no-referrer-when-downgrade">No Referrer When Downgrade</a></code>
-        
-       
-        
+
+
+
        <dt>
           <var>policy</var> is <code>null</code>
-        
-       
-        
+
+
+
        <dd>
-          
+
         <ol>
-            
+
          <li>
               If <var>environment</var> is <a data-link-type="dfn" href="http://www.w3.org/TR/2010/REC-wsc-ui-20100812/#typesoftls">TLS-protected</a> <em>and</em> the
               <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a> of <var>request</var>’s <code>URL</code> is
               an <a data-link-type="dfn" href="https://w3c.github.io/webappsec/specs/mixedcontent/#a-priori-insecure-origin"><em>a priori</em> insecure origin</a>, then return
               <code>no referrer</code>.
-            
-         
-            
+
+
+
          <li>
               Otherwise, return <var>requestURL</var>.
-            
-         
-          
+
+
+
         </ol>
-        
-        
-       
-      
+
+
+
+
       </dl>
-      
-    
-     
-  
+
+
+
+
     </ol>
 
-  
+
     <h3 class="heading settled" data-level="6.3" id="strip-url"><span class="secno">6.3. </span><span class="content">
     Strip <var>url</var> for use as a referrer
   </span><a class="self-link" href="#strip-url"></a></h3>
@@ -1198,65 +1198,65 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
   additionally remove the URL’s path and query components, leaving only the
   scheme, host, and port.</p>
 
-  
+
     <ol>
-    
+
      <li>
       If <var>url</var> is <code>null</code>, return <code>no referrer</code>.
-    
-     
-    
+
+
+
      <li>
       If <var>url</var>’s <code>scheme</code> is a <a data-link-type="dfn" href="http://www.w3.org/TR/url/#local-scheme">local scheme</a>, then
       return <code>no referrer</code>.
-    
-     
-    
+
+
+
      <li>
       Set <var>url</var>’s <code>username</code> to the empty string.
-    
-     
-    
+
+
+
      <li>
       Set <var>url</var>’s <code>password</code> to <code>null</code>.
-    
-     
-    
+
+
+
      <li>
       Set <var>url</var>’s <code>fragment</code> to <code>null</code>.
-    
-     
-    
+
+
+
      <li>
       If the <code><a data-link-type="dfn" href="#origin_only-flag">origin-only flag</a></code> is <code>true</code>,
       then:
 
-      
+
       <ol>
-        
+
        <li>
           Set <var>url</var>’s <code>path</code> to <code>null</code>.
-        
-       
-        
+
+
+
        <li>
           Set <var>url</var>’s <code>query</code> to <code>null</code>.
-        
-       
-      
+
+
+
       </ol>
-      
-    
-     
-    
+
+
+
+
      <li>
       Return <var>url</var>.
-    
-     
-  
+
+
+
     </ol>
 
-  
+
     <h3 class="heading settled" data-level="6.4" id="determine-policy-for-token"><span class="secno">6.4. </span><span class="content">
     Determine <var>token</var>’s Policy
   </span><a class="self-link" href="#determine-policy-for-token"></a></h3>
@@ -1266,48 +1266,48 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
   <a data-link-type="dfn" href="#referrer-directive"><code>referrer</code> directive</a>), this algorithm will return the
   <a data-link-type="dfn" href="#referrer-policy">referrer policy</a> it refers to:</p>
 
-  
+
     <ol>
-    
+
      <li>
       If <var>token</var> is an <a data-link-type="dfn" href="http://www.w3.org/TR/html5/infrastructure.html#ascii-case-insensitive">ASCII case-insensitive match</a> for the
       strings "<code>never</code>" or "<code>no-referrer</code>", return
       <a data-link-type="dfn" href="#no-referrer"><code>No Referrer</code></a>.
-    
-     
-    
+
+
+
      <li>
       If <var>token</var> is an <a data-link-type="dfn" href="http://www.w3.org/TR/html5/infrastructure.html#ascii-case-insensitive">ASCII case-insensitive match</a> for the
       string "<code>origin</code>", return <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2"><code>Origin</code></a>.
-    
-     
-    
+
+
+
      <li>
       If <var>token</var> is <a data-link-type="dfn" href="http://www.w3.org/TR/html5/infrastructure.html#ascii-case-insensitive">ASCII case-insensitive match</a> for the string
       "<code>default</code>" or "<code>no-referrer-when-downgrade</code>",
       return <a data-link-type="dfn" href="#no-referrer-when-downgrade"><code>No Referrer When Downgrade</code></a>.
-    
-     
-    
+
+
+
      <li>
       If <var>token</var> is <a data-link-type="dfn" href="http://www.w3.org/TR/html5/infrastructure.html#ascii-case-insensitive">ASCII case-insensitive match</a> for the string
       "<code>origin-when-crossorigin</code>", return
       <a data-link-type="dfn" href="#origin-when-cross_origin"><code>Origin When Cross-Origin</code></a>.
-    
-     
-    
+
+
+
      <li>
       If <var>token</var> is <a data-link-type="dfn" href="http://www.w3.org/TR/html5/infrastructure.html#ascii-case-insensitive">ASCII case-insensitive match</a> for the strings
       "<code>always</code>" or "<code>unsafe-url</code>",
       return <a data-link-type="dfn" href="#unsafe-url"><code>Unsafe URL</code></a>.
-    
-     
-    
+
+
+
      <li>
       Return <a data-link-type="dfn" href="#no-referrer"><code>No Referrer</code></a>.
-    
-     
-  
+
+
+
     </ol>
 
 
@@ -1320,10 +1320,10 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
 
 
    <section>
-  
+
     <h2 class="heading settled" data-level="7" id="privacy"><span class="secno">7. </span><span class="content">Privacy Considerations</span><a class="self-link" href="#privacy"></a></h2>
 
-  
+
     <h3 class="heading settled" data-level="7.1" id="user-controls"><span class="secno">7.1. </span><span class="content">User Controls</span><a class="self-link" href="#user-controls"></a></h3>
 
 
@@ -1337,14 +1337,14 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
 
 
    <section>
-  
+
     <h2 class="heading settled" data-level="8" id="acknowledgements"><span class="secno">8. </span><span class="content">Acknowledgements</span><a class="self-link" href="#acknowledgements"></a></h2>
 
 
     <p>This specification is based in large part on Adam Barth and Jochen Eisinger’s
   <a href="http://wiki.whatwg.org/wiki/Meta_referrer">Meta referrer</a>
   document.</p>
-</section> 
+</section>
 
 </main>
 
@@ -1353,7 +1353,7 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
 
   <h3 class="no-ref no-num heading settled" id="conventions"><span class="content">Document conventions</span><a class="self-link" href="#conventions"></a></h3>
 
-    
+
   <p>Conformance requirements are expressed with a combination of
     descriptive assertions and RFC 2119 terminology. The key words "MUST",
     "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT",
@@ -1366,20 +1366,20 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
   <p>All of the text of this specification is normative except sections
     explicitly marked as non-normative, examples, and notes. <a data-link-type="biblio" href="#biblio-rfc2119">[RFC2119]</a></p>
 
-    
+
   <p>Examples in this specification are introduced with the words "for example"
     or are set apart from the normative text with <code>class="example"</code>,
     like this:
 
     </p>
   <div class="example">
-        
+
    <p>This is an example of an informative example.</p>
-   
-    
+
+
   </div>
 
-    
+
   <p>Informative notes begin with the word "Note" and are set apart from the
     normative text with <code>class="note"</code>, like this:
 
@@ -1389,13 +1389,13 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
 
   <h3 class="no-ref no-num heading settled" id="conformant-algorithms"><span class="content">Conformant Algorithms</span><a class="self-link" href="#conformant-algorithms"></a></h3>
 
-    
+
   <p>Requirements phrased in the imperative as part of algorithms (such as
     "strip any leading space characters" or "return false and abort these
     steps") are to be interpreted with the meaning of the key word ("must",
     "should", "may", etc) used in introducing the algorithm.</p>
 
-    
+
   <p>Conformance requirements phrased as algorithms or specific steps can be
     implemented in any manner, so long as the end result is equivalent. In
     particular, the algorithms defined in this specification are intended to
@@ -1405,11 +1405,11 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
 
   <h3 class="no-ref no-num heading settled" id="conformance-classes"><span class="content">Conformance Classes</span><a class="self-link" href="#conformance-classes"></a></h3>
 
-    
+
   <p>A <dfn data-dfn-type="dfn" data-noexport="" id="conformant-user-agent">conformant user agent<a class="self-link" href="#conformant-user-agent"></a></dfn> must implement all the requirements
     listed in this specification that are applicable to user agents.</p>
 
-    
+
   <p>A <dfn data-dfn-type="dfn" data-noexport="" id="conformant-server">conformant server<a class="self-link" href="#conformant-server"></a></dfn> must implement all the requirements listed
     in this specification that are applicable to servers.</p>
 

--- a/specs/referrer-policy/index.html
+++ b/specs/referrer-policy/index.html
@@ -1,16 +1,16 @@
 <!doctype html>
 <html lang="en">
  <head>
-
+  
   <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
-
-
+  
+  
   <title>Referrer Policy</title>
-
-
+  
+  
   <link href="../default.css" rel="stylesheet" type="text/css">
-
-
+  
+  
   <style>
   body {
     background: url("https://www.w3.org/StyleSheets/TR/logo-ED") top left no-repeat white;
@@ -53,26 +53,26 @@
     list-style: none;
   }
   </style>
-
+  
 
   <meta content="Bikeshed 1.0.0" name="generator">
  </head>
-
+ 
 
  <body class="h-entry">
 
   <div class="head">
-
+  
    <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/">
     <img alt="W3C" height="48" src="https://www.w3.org/Icons/w3c_home" width="72">
 </a>
 </p>
-
+  
    <h1 class="p-name no-ref" id="title">Referrer Policy</h1>
-
+  
    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft,
     <time class="dt-updated" datetime="2015-03-03">3 March 2015</time></span></h2>
-
+  
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -90,12 +90,12 @@
      <dd class="editor p-author h-card vcard"><a class="p-name fn u-email email" href="mailto:mkwst@google.com">Mike West</a> (<span class="p-org org">Google Inc.</span>)
     </dl>
    </div>
-
+  
    <div data-fill-with="warning"></div>
-
+  
    <p class="copyright" data-fill-with="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2015 <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.
 </p>
-
+  
    <hr title="Separator for header">
 </div>
 
@@ -244,7 +244,7 @@
 
 
    <section>
-
+  
     <h2 class="heading settled" data-level="1" id="intro"><span class="secno">1. </span><span class="content">Introduction</span><a class="self-link" href="#intro"></a></h2>
 
 
@@ -257,7 +257,7 @@
   type, authors might wish to control the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header
   more directly for a number of reasons:</p>
 
-
+  
     <h3 class="heading settled" data-level="1.1" id="intro-privacy"><span class="secno">1.1. </span><span class="content">Privacy</span><a class="self-link" href="#intro-privacy"></a></h3>
 
 
@@ -272,7 +272,7 @@
   that the links originated from the social networking site but not reveal which
   specific user’s profile contained the links.</p>
 
-
+  
     <h3 class="heading settled" data-level="1.2" id="intro-security"><span class="secno">1.2. </span><span class="content">Security</span><a class="self-link" href="#intro-security"></a></h3>
 
 
@@ -285,7 +285,7 @@
   capability. Controlling the referrer can help prevent these capability URLs
   from leaking via referrer headers. <a data-link-type="biblio" href="#biblio-capability-urls">[CAPABILITY-URLS]</a></p>
 
-
+  
     <h3 class="heading settled" data-level="1.3" id="intro-trackback"><span class="secno">1.3. </span><span class="content">Trackback</span><a class="self-link" href="#intro-trackback"></a></h3>
 
 
@@ -297,17 +297,17 @@
 
 
    <section>
-
+  
     <h2 class="heading settled" data-level="2" id="terms"><span class="secno">2. </span><span class="content">Key Concepts and Terminology</span><a class="self-link" href="#terms"></a></h2>
 
-
+  
     <dl>
-
+    
      <dt>
       <dfn data-dfn-type="dfn" data-export="" data-local-lt="policy" id="referrer-policy">referrer policy<a class="self-link" href="#referrer-policy"></a></dfn>
-
-
-
+    
+     
+    
      <dd>
       A <strong>referrer policy</strong> is a property of a <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#settings-object">settings
       object</a> that defines the algorithm used to populate the
@@ -318,40 +318,40 @@
       <p>If no referrer policy is explicitly set for a <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#settings-object">settings object</a>,
       then the value of the property is <code>null</code>. Otherwise, the value
       is whatever has been explicitly set, as explained in the
-      <a href="#set-referrer-policy">§6.1
+      <a href="#set-referrer-policy">§6.1 
     Set environment’s referrer policy to policy
   </a> algorithm.</p>
+      
+    
+     
 
-
-
-
-
+    
      <dt><dfn data-dfn-type="dfn" data-local-lt="same-origin" data-noexport="" id="same_origin-request">same-origin request<a class="self-link" href="#same_origin-request"></a></dfn>
-
-
+     
+    
      <dd>
       A <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#request">Request</a></code> <var>request</var> is a <strong>same-origin request</strong>
       if <var>request</var>’s <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#concept-request-origin">origin</a></code> and the <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a> of
       <var>request</var>’s <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#concept-request-url">url</a></code> are <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-5"><code>the same</code></a>.
+    
+     
 
-
-
-
+    
      <dt><dfn data-dfn-type="dfn" data-local-lt="cross-origin" data-noexport="" id="cross_origin-request">cross-origin request<a class="self-link" href="#cross_origin-request"></a></dfn>
-
-
+     
+    
      <dd>
       A <code class="idl"><a data-link-type="idl" href="https://fetch.spec.whatwg.org/#request">Request</a></code> is a <strong>cross-origin request</strong> if it is
       <em>not</em> <a data-link-type="dfn" href="#same_origin-request">same-origin</a>.
-
-
-
+    
+     
+  
     </dl>
 </section>
 
 
    <section>
-
+  
     <h2 class="heading settled" data-level="3" id="referrer-policy-states"><span class="secno">3. </span><span class="content">Referrer Policy States</span><a class="self-link" href="#referrer-policy-states"></a></h2>
 
 
@@ -371,7 +371,7 @@
   baseline policy for requests. This policy may be tightened for specific
   requests via mechanisms like the <code><a data-link-type="dfn" href="http://www.w3.org/TR/html5/links.html#link-type-noreferrer">noreferrer</a></code> link type.</p>
 
-
+  
     <h3 class="heading settled" data-level="3.1" id="referrer-policy-state-no-referrer"><span class="secno">3.1. </span><span class="content">No Referrer</span><a class="self-link" href="#referrer-policy-state-no-referrer"></a></h3>
 
 
@@ -380,7 +380,7 @@
   <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#settings-object">settings object</a> to any <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a>. The header will be omitted
   entirely.</p>
 
-
+  
     <div class="example">
     If a document at <code>https://example.com/page.html</code> sets a policy of
     <code>No Referrer</code>, then navigations to
@@ -388,7 +388,7 @@
     <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header.
   </div>
 
-
+  
     <h3 class="heading settled" data-level="3.2" id="referrer-policy-state-no-referrer-when-downgrade"><span class="secno">3.2. </span><span class="content">No Referrer When Downgrade</span><a class="self-link" href="#referrer-policy-state-no-referrer-when-downgrade"></a></h3>
 
 
@@ -403,7 +403,7 @@
   priori</em> insecure origins</a>, on the other hand, will contain no referrer
   information. A <code><a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2">Referer</a></code> HTTP header will not be sent.</p>
 
-
+  
     <div class="example">
     If a document at <code>https://example.com/page.html</code> sets a policy of
     <code>No Referrer When Downgrade</code>, then navigations to
@@ -416,14 +416,14 @@
      <p>Navigations from that same page to
     <code><strong>http</strong>://not.example.com/</code> would send no
     <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header.</p>
-
-
+     
+  
     </div>
 
 
     <p>This is a user agent’s default behavior, if no policy is otherwise specified.</p>
 
-
+  
     <h3 class="heading settled" data-level="3.3" id="referrer-policy-state-origin"><span class="secno">3.3. </span><span class="content">Origin Only</span><a class="self-link" href="#referrer-policy-state-origin"></a></h3>
 
 
@@ -445,7 +445,7 @@
     <p class="note" role="note">Note: The <code>Origin Only</code> policy causes the origin of HTTPS referrers
   to be sent over the network as part of unencrypted HTTP requests.</p>
 
-
+  
     <div class="example">
     If a document at <code>https://example.com/page.html</code> sets a policy of
     <code>Origin Only</code>, then navigations to any <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a> would send a
@@ -454,7 +454,7 @@
     origins</a>.
   </div>
 
-
+  
     <h3 class="heading settled" data-level="3.4" id="referrer-policy-state-origin-when-cross-origin"><span class="secno">3.4. </span><span class="content">Origin When Cross-Origin</span><a class="self-link" href="#referrer-policy-state-origin-when-cross-origin"></a></h3>
 
 
@@ -477,7 +477,7 @@
   HTTPS referrers to be sent over the network as part of unencrypted HTTP
   requests.</p>
 
-
+  
     <div class="example">
     If a document at <code>https://example.com/page.html</code> sets a policy of
     <code>Origin When Cross-Origin</code>, then navigations to any
@@ -490,11 +490,11 @@
     would send a <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc7231#section-5.5.2"><code>Referer</code></a> header with a value of
     <code>https://example.com/</code>, even to <a data-link-type="dfn" href="https://w3c.github.io/webappsec/specs/mixedcontent/#a-priori-insecure-origin"><em>a priori</em> insecure
     origins</a>.</p>
-
-
+     
+  
     </div>
 
-
+  
     <h3 class="heading settled" data-level="3.5" id="referrer-policy-state-unsafe-url"><span class="secno">3.5. </span><span class="content">Unsafe URL</span><a class="self-link" href="#referrer-policy-state-unsafe-url"></a></h3>
 
 
@@ -503,7 +503,7 @@
   both <a data-link-type="dfn" href="#cross_origin-request">cross-origin requests</a> and <a data-link-type="dfn" href="#same_origin-request">same-origin requests</a> made from
   a particular <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#settings-object">settings object</a>.</p>
 
-
+  
     <div class="example">
     If a document at <code>https://example.com/sekrit.html</code> sets a policy
     of <code>Unsafe URL</code>, then navigations to
@@ -521,51 +521,51 @@
 
 
    <section>
-
+  
     <h2 class="heading settled" data-level="4" id="referrer-policy-delivery"><span class="secno">4. </span><span class="content">Referrer Policy Delivery</span><a class="self-link" href="#referrer-policy-delivery"></a></h2>
 
 
-    <p>A <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#settings-object">settings object</a>’s <a data-link-type="dfn" href="#referrer-policy">referrer policy</a> is delivered in one of four
+    <p>A <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#settings-object">settings object</a>’s <a data-link-type="dfn" href="#referrer-policy">referrer policy</a> is deliveredin one of four
   ways:</p>
 
-
+  
     <ul>
-
+    
      <li>
       Via the <code>referrer</code> Content Security Policy directive (defined
       in <a href="#directive-referrer">§4.1 Delivery via CSP</a>), delivered via the
       <a href="https://w3c.github.io/webappsec/specs/content-security-policy/#content-security-policy-header-field"><code>Content-Security-Policy</code></a>
       HTTP header. <a data-link-type="biblio" href="#biblio-csp2">[CSP2]</a>
-
-
-
+    
+     
+    
      <li>
       Via the <code>referrer</code> Content Security Policy directive (defined
       in <a href="#directive-referrer">§4.1 Delivery via CSP</a>), delivered via a
       <a href="https://w3c.github.io/webappsec/specs/content-security-policy/#delivery-html-meta-element"><code>&lt;meta></code> element</a>
       <a data-link-type="biblio" href="#biblio-csp2">[CSP2]</a>
-
-
-
+    
+     
+    
      <li>
       Via a <code><a data-link-type="element" href="http://www.w3.org/TR/html5/document-metadata.html#the-meta-element">meta</a></code> element with a <code><a data-link-type="element-attr" href="http://www.w3.org/TR/html5/document-metadata.html#attr-meta-name">name</a></code> of <code>referrer</code>.
-
-
-
+    
+     
+    
      <li>
       Via a <code>referrer</code> attribute on an <code><a data-link-type="element" href="http://www.w3.org/TR/html5/text-level-semantics.html#the-a-element">a</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/#the-area-element">area</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/#the-img-element">img</a></code>
       or <code><a data-link-type="element" href="http://www.w3.org/TR/html5/embedded-content-0.html#the-iframe-element">iframe</a></code> element.
-
-
-
+    
+     
+    
      <li>
       Implicitly, via inheritance.
-
-
-
+    
+     
+  
     </ul>
 
-
+  
     <h3 class="heading settled" data-level="4.1" id="directive-referrer"><span class="secno">4.1. </span><span class="content">Delivery via CSP</span><a class="self-link" href="#directive-referrer"></a></h3>
 
 
@@ -576,7 +576,7 @@
   The syntax for the name and value of the directive are described by the
   following ABNF grammar:</p>
 
-
+  
     <pre>directive-name    = "referrer"
 directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "origin-when-cross-origin" / "unsafe-url"
 </pre>
@@ -588,43 +588,43 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
     <p>When
   <a href="https://w3c.github.io/webappsec/specs/content-security-policy/#enforce">enforcing</a>
   the <code>referrer</code> directive, the user agent MUST execute
-  <a href="#set-referrer-policy">§6.1
+  <a href="#set-referrer-policy">§6.1 
     Set environment’s referrer policy to policy
   </a> on the protected resource’s <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#incumbent-settings-object">incumbent settings
-  object</a>, using the result of executing <a href="#determine-policy-for-token">§6.4
+  object</a>, using the result of executing <a href="#determine-policy-for-token">§6.4 
     Determine token’s Policy
   </a>
   on the <code>referrer</code> directive’s value.</p>
 
-
+  
     <section class="informative">
-
+    
      <h4 class="heading settled" data-level="4.1.1" id="referrer-usage"><span class="secno">4.1.1. </span><span class="content">Usage</span><a class="self-link" href="#referrer-usage"></a></h4>
-
+     
 
 
      <p><em>This section is not normative.</em></p>
-
+     
 
 
      <p>A protected resource can prevent referrer leakage by specifying
     <code>no-referrer</code> as the value of its policy’s
     <code>referrer</code> directive:</p>
+     
 
-
-
+    
      <pre>Content-Security-Policy: referrer no-referrer;
 </pre>
-
+     
 
 
      <p>This will cause all requests made from the protected resource’s
     context to have an empty <code>Referer</code> [sic] header.</p>
-
-
+     
+  
     </section>
 
-
+  
     <h3 class="heading settled" data-level="4.2" id="referrer-policy-delivery-meta"><span class="secno">4.2. </span><span class="content">Delivery via <code><a data-link-type="element" href="http://www.w3.org/TR/html5/document-metadata.html#the-meta-element">meta</a></code></span><a class="self-link" href="#referrer-policy-delivery-meta"></a></h3>
 
 
@@ -633,7 +633,7 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
   for the string "<code>Referrer</code>" is inserted into a document, for
   example:</p>
 
-
+  
     <pre class="example">&lt;meta name="referrer" content="origin">
 </pre>
 
@@ -641,39 +641,39 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
     <p>The following values for the <code>content</code> attribute are valid, and map
   to the listed <a data-link-type="dfn" href="#referrer-policy">referrer policy</a> values:</p>
 
-
+  
     <dl>
-
+    
      <dt>no-referrer
-
-
+     
+    
      <dd><a data-link-type="dfn" href="#no-referrer"><code>No Referrer</code></a>
-
-
+     
+    
      <dt>origin
-
-
+     
+    
      <dd><a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2"><code>Origin</code></a>
-
-
+     
+    
      <dt>no-referrer-when-downgrade
-
-
+     
+    
      <dd><a data-link-type="dfn" href="#no-referrer-when-downgrade"><code>No Referrer When Downgrade</code></a>
-
-
+     
+    
      <dt>origin-when-crossorigin
-
-
+     
+    
      <dd><a data-link-type="dfn" href="#origin-when-cross_origin"><code>Origin When Cross-Origin</code></a>
-
-
+     
+    
      <dt>unsafe-url
-
-
+     
+    
      <dd><a data-link-type="dfn" href="#unsafe-url"><code>Unsafe URL</code></a>
-
-
+     
+  
     </dl>
 
 
@@ -681,75 +681,75 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
   <a href="http://www.w3.org/TR/html5/document-metadata.html#pragma-directives">pragma directives</a>
   for the <code><a data-link-type="element" href="http://www.w3.org/TR/html5/document-metadata.html#the-meta-element">meta</a></code> element:</p>
 
-
+  
     <dl>
-
+    
      <dt>
       Referrer policy
       (<code>name="Referrer"</code>)
-
-
-
+    
+     
+    
      <dd>
-
+      
       <ol>
-
+        
        <li>
           If the Document’s <code><a data-link-type="element" href="https://html.spec.whatwg.org/#the-head-element">head</a></code> element is not an ancestor of the <code><a data-link-type="element" href="http://www.w3.org/TR/html5/document-metadata.html#the-meta-element">meta</a></code>
           element, abort these steps.
+        
+       
 
-
-
-
+        
        <li>
           If the <code><a data-link-type="element" href="http://www.w3.org/TR/html5/document-metadata.html#the-meta-element">meta</a></code> element lacks a <code><a data-link-type="element-attr" href="http://www.w3.org/TR/html5/document-metadata.html#attr-meta-content">content</a></code> attribute then abort
           these steps.
+        
+       
 
-
-
-
+        
        <li>
           Let <var>environment</var> be the <code class="idl"><a data-link-type="idl" href="http://www.w3.org/TR/dom/#interface-document">Document</a></code>'s <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#incumbent-settings-object">incumbent settings
           object</a>.
+        
+       
 
-
-
-
+        
        <li>
           Let <var>meta-value</var> be the value of the element’s
           <code><a data-link-type="element-attr" href="http://www.w3.org/TR/html5/document-metadata.html#attr-meta-content">content</a></code> attribute, after
           <a data-link-type="dfn" href="http://www.w3.org/TR/html5/infrastructure.html#strip-leading-and-trailing-whitespace">stripping
           leading and trailing whitespace</a>.
+        
+       
 
-
-
-
+        
        <li>
           If <var>meta-value</var> is the empty string, then abort these steps.
+        
+       
 
-
-
-
+        
        <li>
           Let <var>policy</var> be the result of executing the
-          <a href="#determine-policy-for-token">§6.4
+          <a href="#determine-policy-for-token">§6.4 
     Determine token’s Policy
   </a> algorithm on <var>meta-value</var>.
+        
+       
 
-
-
-
+        
        <li>
-          Execute the <a href="#set-referrer-policy">§6.1
+          Execute the <a href="#set-referrer-policy">§6.1 
     Set environment’s referrer policy to policy
   </a> algorithm on
           <var>environment</var> using <var>policy</var>, if <var>policy</var>
           is not <code>null</code>.
-
-
-
+        
+       
+      
       </ol>
-
+      
 
 
       <p class="note" role="note">Note: Authors are encouraged to avoid the legacy keywords
@@ -757,19 +757,19 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
       keywords <code>no-referrer</code>,
       <code>no-referrer-when-downgrade</code>, and <code>unsafe-url</code>
       respectively are preferred.</p>
-
+      
 
 
       <p class="note" role="note">Note: Implementors are advised to also respect a <a data-link-type="dfn" href="#referrer-policy">referrer policy</a>
       delivered via a <code><a data-link-type="element" href="http://www.w3.org/TR/html5/document-metadata.html#the-meta-element">meta</a></code> element during
       speculative resource loads.</p>
-
-
-
-
+      
+    
+     
+  
     </dl>
 
-
+  
     <h3 class="heading settled" data-level="4.3" id="referrer-policy-delivery-referrer-attribute"><span class="secno">4.3. </span><span class="content">Delivery
   via a <code>referrer</code> attribute</span><a class="self-link" href="#referrer-policy-delivery-referrer-attribute"></a></h3>
 
@@ -779,7 +779,7 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
   <code><a data-link-type="element" href="https://html.spec.whatwg.org/#the-img-element">img</a></code> or <code><a data-link-type="element" href="http://www.w3.org/TR/html5/embedded-content-0.html#the-iframe-element">iframe</a></code>
   element, for example:</p>
 
-
+  
     <pre class="example">&lt;a href="http://example.com" referrer="origin">
 </pre>
 
@@ -787,27 +787,27 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
     <p>The following values for the <code>referrer</code> attribute are valid,
   and map to the listed <a data-link-type="dfn" href="#referrer-policy">referrer policy</a> values:</p>
 
-
+  
     <dl>
-
+    
      <dt>no-referrer
-
-
+     
+    
      <dd><a data-link-type="dfn" href="#no-referrer"><code>No Referrer</code></a>
-
-
+     
+    
      <dt>origin
-
-
+     
+    
      <dd><a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2"><code>Origin</code></a>
-
-
+     
+    
      <dt>unsafe-url
-
-
+     
+    
      <dd><a data-link-type="dfn" href="#unsafe-url"><code>Unsafe URL</code></a>
-
-
+     
+  
     </dl>
 
 
@@ -827,14 +827,14 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
   by <a href="https://lists.w3.org/Archives/Public/public-webappsec/2015Feb/0283.html">Brian
   Smith</a> and honor the <code>noreferrer</code> link type?</p>
 
-
+  
     <h3 class="heading settled" data-level="4.4" id="referrer-policy-delivery-implicit"><span class="secno">4.4. </span><span class="content">Implicit Delivery</span><a class="self-link" href="#referrer-policy-delivery-implicit"></a></h3>
 
 
     <p>A <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#settings-object">settings object</a> inherits the <a data-link-type="dfn" href="#referrer-policy">referrer policy</a> of another object
   in several circumstances:</p>
 
-
+  
     <h4 class="heading settled" data-level="4.4.1" id="referrer-policy-delivery-implicit-nested"><span class="secno">4.4.1. </span><span class="content">
      Nested Browsing Contexts
   </span><a class="self-link" href="#referrer-policy-delivery-implicit-nested"></a></h4>
@@ -845,33 +845,33 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
   is a <a data-link-type="dfn" href="http://www.w3.org/TR/url/#local-scheme">local scheme</a> (for instance, a <code>blob</code> or
   <code>data</code> resource):</p>
 
-
+  
     <ol>
-
+    
      <li>
       Let <var>environment</var> be the <a data-link-type="dfn" href="http://www.w3.org/TR/html5/browsers.html#nested-browsing-context">nested browsing context</a>’s
       <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#incumbent-settings-object">incumbent settings object</a>.
-
-
-
+    
+     
+    
      <li>
       Let <var>policy</var> be the <a data-link-type="dfn" href="http://www.w3.org/TR/html5/browsers.html#parent-browsing-context">parent browsing context</a>’s
       <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#incumbent-settings-object">incumbent settings object</a>’s <a data-link-type="dfn" href="#referrer-policy">referrer policy</a>.
-
-
-
+    
+     
+    
      <li>
-      Execute the <a href="#set-referrer-policy">§6.1
+      Execute the <a href="#set-referrer-policy">§6.1 
     Set environment’s referrer policy to policy
   </a> algorithm on
       <var>environment</var> using <var>policy</var>, if <var>policy</var>
       is not <code>null</code>.
-
-
-
+    
+     
+  
     </ol>
 
-
+  
     <h4 class="heading settled" data-level="4.4.2" id="referrer-policy-delivery-implicit-workers"><span class="secno">4.4.2. </span><span class="content">
     Workers
   </span><a class="self-link" href="#referrer-policy-delivery-implicit-workers"></a></h4>
@@ -880,34 +880,34 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
     <p>Whenever a user agent <a data-link-type="dfn" href="http://www.w3.org/TR/workers/#run-a-worker">runs a worker</a> for a script with <code class="idl"><a data-link-type="idl" href="http://www.w3.org/TR/url/#url">URL</a></code>
   <var>url</var> and <var>url</var>’s scheme is a <a data-link-type="dfn" href="http://www.w3.org/TR/url/#local-scheme">local scheme</a>:</p>
 
-
+  
     <ol>
-
+    
      <li>
       Let <var>environment</var> be the Worker’s <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#incumbent-settings-object">incumbent settings
       object</a>.
-
-
-
+    
+     
+    
      <li>
       Let <var>policy</var> be <code>No Referrer When Downgrade</code>.
-
-
-
+    
+     
+    
      <li>
-      Execute the <a href="#set-referrer-policy">§6.1
+      Execute the <a href="#set-referrer-policy">§6.1 
     Set environment’s referrer policy to policy
   </a> algorithm on
       <var>environment</var> using <var>policy</var>.
-
-
-
+    
+     
+  
     </ol>
 </section>
 
 
    <section>
-
+  
     <h2 class="heading settled" data-level="5" id="integration-with-fetch"><span class="secno">5. </span><span class="content">Integration with Fetch</span><a class="self-link" href="#integration-with-fetch"></a></h2>
 
 
@@ -923,10 +923,10 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
 
 
    <section>
-
+  
     <h2 class="heading settled" data-level="6" id="algorithms"><span class="secno">6. </span><span class="content">Algorithms</span><a class="self-link" href="#algorithms"></a></h2>
 
-
+  
     <h3 class="heading settled" data-level="6.1" id="set-referrer-policy"><span class="secno">6.1. </span><span class="content">
     Set <var>environment</var>’s referrer policy to <var>policy</var>
   </span><a class="self-link" href="#set-referrer-policy"></a></h3>
@@ -936,28 +936,28 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
   setting its value is straightforward. If a policy has previously been set,
   then we overwrite it with the new value.</p>
 
-
+  
     <ol>
-
+    
      <li>
       If <var>policy</var> is not one of <code><a data-link-type="dfn" href="#no-referrer">No Referrer</a></code>,
       <code><a data-link-type="dfn" href="#no-referrer-when-downgrade">No Referrer When Downgrade</a></code>, <code><a data-link-type="dfn" href="#origin-only">Origin
       Only</a></code>, <code><a data-link-type="dfn" href="#origin-when-cross_origin">Origin when cross-origin</a></code>, or
       <code><a data-link-type="dfn" href="#unsafe-url">Unsafe URL</a></code>, then return without setting
       <var>environment</var>’s referrer policy.
+    
+     
 
-
-
-
+    
      <li>
       Set <var>environment</var>’s <a data-link-type="dfn" href="#referrer-policy">referrer policy</a> to
       <var>policy</var>.
-
-
-
+    
+     
+  
     </ol>
 
-
+  
     <h3 class="heading settled" data-level="6.2" id="determine-requests-referrer"><span class="secno">6.2. </span><span class="content">
     Determine <var>request</var>’s Referrer
   </span><a class="self-link" href="#determine-requests-referrer"></a></h3>
@@ -978,213 +978,213 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
     <p class="issue" id="issue-2cf94c0c"><a class="self-link" href="#issue-2cf94c0c"></a>This algorithm needs to be modifed to take into account any local
   overrides via the referrer attribute on elements.</p>
 
-
+  
     <ol>
-
+    
      <li>
       Let <var>environment</var> be <var>request</var>’s <code>client</code>.
-
-
-
+    
+     
+    
      <li>
       Let <var>policy</var> be the value of <var>environment</var>’s
       <a data-link-type="dfn" href="#referrer-policy">referrer policy</a>.
-
-
-
+    
+     
+    
      <li>
       If <var>request</var>’s <code>referrer</code> is a URL, then let
       <var>referrerSource</var> be <var>request</var>’s
       <code>referrer</code>. Otherwise:
 
-
+      
       <ol>
-
+        
        <li>
           If <var>environment</var> is a <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#document-environment">document environment</a>:
 
-
+          
         <ol>
-
+            
          <li>
               Let <var>document</var> be the <code class="idl"><a data-link-type="idl" href="http://www.w3.org/TR/dom/#interface-document">Document</a></code> object of the
               <a data-link-type="dfn" href="http://www.w3.org/TR/html5/browsers.html#active-document">active document</a> of the <a data-link-type="dfn" href="http://www.w3.org/TR/html5/browsers.html#browsing-context">browsing context</a> of
               <var>environment</var>’s <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#responsible-browsing-context">responsible browsing context</a>.
-
-
-
+            
+         
+          
         </ol>
-
-
-
-
+        
+        
+       
+        
        <li>
           Otherwise, <var>environment</var> is a <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#worker-environment">worker environment</a>:
 
-
+          
         <ol>
-
+            
          <li>
               Let <var>source</var> be the <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#api-referrer-source">API referrer source</a>
               specified by the <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#incumbent-settings-object">incumbent settings object</a>.
-
-
-
+            
+         
+            
          <li>
               If <var>source</var> is a URL, let <var>referrerSource</var>
               be <var>source</var>, otherwise let <var>document</var> be
               <var>source</var>.
-
-
-
+            
+         
+          
         </ol>
-
-
-
-
+        
+        
+       
+        
        <li>
           If <var>document</var> is set, execute the following steps:
 
-
+          
         <ol>
-
+            
          <li>
               If <var>document</var>’s <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a> is not a scheme/host/port
               tuple (because, for example, it has been sandboxed into a unique
               origin), return <code>no referrer</code> and abort these steps.
-
-
-
+            
+         
+            
          <li>
               While <var>document</var> corresponds to <a data-link-type="dfn" href="http://www.w3.org/TR/html5/embedded-content-0.html#an-iframe-srcdoc-document">an iframe srcdoc Document</a>,
               let <var>document</var> be that Document’s <a data-link-type="dfn" href="http://www.w3.org/TR/html5/browsers.html#browsing-context">browsing context</a>’s
               <a data-link-type="dfn" href="http://www.w3.org/TR/html5/browsers.html#browsing-context-container">browsing context container</a>’s <code class="idl"><a data-link-type="idl" href="http://www.w3.org/TR/dom/#interface-document">Document</a></code>.
-
-
-
+            
+         
+            
          <li>
               Let <var>referrerSource</var> be <var>document</var>’s URL.
-
-
-
+            
+         
+          
         </ol>
-
-
-
-
+        
+        
+       
+      
       </ol>
-
-
-
-
+      
+    
+     
+    
      <li>
       Let <var>referrerURL</var> be the result of <a href="#strip-url">stripping
       <var>referrerSource</var> for use as a referrer.</a>
-
-
-
+    
+     
+    
      <li>
       Let <var>referrerOrigin</var> be the result of
       <a href="#strip-url">stripping <var>referrerSource</var> for use as a
       referrer</a>, with the <code><a data-link-type="dfn" href="#origin_only-flag">origin-only flag</a></code> set to
       <code>true</code>.
+    
+     
 
-
-
-
+    
      <li>
       Execute the statements corresponding to the value of <var>policy</var>:
 
-
+      
       <dl>
-
+        
        <dt><var>policy</var> is <code><a data-link-type="dfn" href="#no-referrer">No Referrer</a></code>
-
-
+       
+        
        <dd>Return <code>no referrer</code>
+       
 
-
-
+        
        <dt><var>policy</var> is <code><a data-link-type="dfn" href="#origin-only">Origin Only</a></code>
-
-
+       
+        
        <dd>Return <var>referrerOrigin</var>
+       
 
-
-
+        
        <dt><var>policy</var> is <code><a data-link-type="dfn" href="#unsafe-url">Unsafe URL</a></code>
-
-
+       
+        
        <dd>Return <var>referrerURL</var>.
+       
 
-
-
+        
        <dt>
           <var>policy</var> is <code><a data-link-type="dfn" href="#origin-when-cross_origin">Origin When Cross-Origin</a></code>
-
-
-
+        
+       
+        
        <dd>
-
+          
         <ol>
-
+            
          <li>
               If <var>request</var> is a <a data-link-type="dfn" href="#cross_origin-request">cross-origin request</a>, then
               return <var>referrerOrigin</var>.
-
-
-
+            
+         
+            
          <li>
               Otherwise, return <var>referrerURL</var>.
-
-
-
+            
+         
+          
         </ol>
+        
+        
+       
 
-
-
-
-
+        
        <dt>
           <var>policy</var> is <code><a data-link-type="dfn" href="#no-referrer-when-downgrade">No Referrer When Downgrade</a></code>
-
-
-
+        
+       
+        
        <dt>
           <var>policy</var> is <code>null</code>
-
-
-
+        
+       
+        
        <dd>
-
+          
         <ol>
-
+            
          <li>
               If <var>environment</var> is <a data-link-type="dfn" href="http://www.w3.org/TR/2010/REC-wsc-ui-20100812/#typesoftls">TLS-protected</a> <em>and</em> the
               <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2">origin</a> of <var>request</var>’s <code>URL</code> is
               an <a data-link-type="dfn" href="https://w3c.github.io/webappsec/specs/mixedcontent/#a-priori-insecure-origin"><em>a priori</em> insecure origin</a>, then return
               <code>no referrer</code>.
-
-
-
+            
+         
+            
          <li>
               Otherwise, return <var>requestURL</var>.
-
-
-
+            
+         
+          
         </ol>
-
-
-
-
+        
+        
+       
+      
       </dl>
-
-
-
-
+      
+    
+     
+  
     </ol>
 
-
+  
     <h3 class="heading settled" data-level="6.3" id="strip-url"><span class="secno">6.3. </span><span class="content">
     Strip <var>url</var> for use as a referrer
   </span><a class="self-link" href="#strip-url"></a></h3>
@@ -1198,65 +1198,65 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
   additionally remove the URL’s path and query components, leaving only the
   scheme, host, and port.</p>
 
-
+  
     <ol>
-
+    
      <li>
       If <var>url</var> is <code>null</code>, return <code>no referrer</code>.
-
-
-
+    
+     
+    
      <li>
       If <var>url</var>’s <code>scheme</code> is a <a data-link-type="dfn" href="http://www.w3.org/TR/url/#local-scheme">local scheme</a>, then
       return <code>no referrer</code>.
-
-
-
+    
+     
+    
      <li>
       Set <var>url</var>’s <code>username</code> to the empty string.
-
-
-
+    
+     
+    
      <li>
       Set <var>url</var>’s <code>password</code> to <code>null</code>.
-
-
-
+    
+     
+    
      <li>
       Set <var>url</var>’s <code>fragment</code> to <code>null</code>.
-
-
-
+    
+     
+    
      <li>
       If the <code><a data-link-type="dfn" href="#origin_only-flag">origin-only flag</a></code> is <code>true</code>,
       then:
 
-
+      
       <ol>
-
+        
        <li>
           Set <var>url</var>’s <code>path</code> to <code>null</code>.
-
-
-
+        
+       
+        
        <li>
           Set <var>url</var>’s <code>query</code> to <code>null</code>.
-
-
-
+        
+       
+      
       </ol>
-
-
-
-
+      
+    
+     
+    
      <li>
       Return <var>url</var>.
-
-
-
+    
+     
+  
     </ol>
 
-
+  
     <h3 class="heading settled" data-level="6.4" id="determine-policy-for-token"><span class="secno">6.4. </span><span class="content">
     Determine <var>token</var>’s Policy
   </span><a class="self-link" href="#determine-policy-for-token"></a></h3>
@@ -1266,48 +1266,48 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
   <a data-link-type="dfn" href="#referrer-directive"><code>referrer</code> directive</a>), this algorithm will return the
   <a data-link-type="dfn" href="#referrer-policy">referrer policy</a> it refers to:</p>
 
-
+  
     <ol>
-
+    
      <li>
       If <var>token</var> is an <a data-link-type="dfn" href="http://www.w3.org/TR/html5/infrastructure.html#ascii-case-insensitive">ASCII case-insensitive match</a> for the
       strings "<code>never</code>" or "<code>no-referrer</code>", return
       <a data-link-type="dfn" href="#no-referrer"><code>No Referrer</code></a>.
-
-
-
+    
+     
+    
      <li>
       If <var>token</var> is an <a data-link-type="dfn" href="http://www.w3.org/TR/html5/infrastructure.html#ascii-case-insensitive">ASCII case-insensitive match</a> for the
       string "<code>origin</code>", return <a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2"><code>Origin</code></a>.
-
-
-
+    
+     
+    
      <li>
       If <var>token</var> is <a data-link-type="dfn" href="http://www.w3.org/TR/html5/infrastructure.html#ascii-case-insensitive">ASCII case-insensitive match</a> for the string
       "<code>default</code>" or "<code>no-referrer-when-downgrade</code>",
       return <a data-link-type="dfn" href="#no-referrer-when-downgrade"><code>No Referrer When Downgrade</code></a>.
-
-
-
+    
+     
+    
      <li>
       If <var>token</var> is <a data-link-type="dfn" href="http://www.w3.org/TR/html5/infrastructure.html#ascii-case-insensitive">ASCII case-insensitive match</a> for the string
       "<code>origin-when-crossorigin</code>", return
       <a data-link-type="dfn" href="#origin-when-cross_origin"><code>Origin When Cross-Origin</code></a>.
-
-
-
+    
+     
+    
      <li>
       If <var>token</var> is <a data-link-type="dfn" href="http://www.w3.org/TR/html5/infrastructure.html#ascii-case-insensitive">ASCII case-insensitive match</a> for the strings
       "<code>always</code>" or "<code>unsafe-url</code>",
       return <a data-link-type="dfn" href="#unsafe-url"><code>Unsafe URL</code></a>.
-
-
-
+    
+     
+    
      <li>
       Return <a data-link-type="dfn" href="#no-referrer"><code>No Referrer</code></a>.
-
-
-
+    
+     
+  
     </ol>
 
 
@@ -1320,10 +1320,10 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
 
 
    <section>
-
+  
     <h2 class="heading settled" data-level="7" id="privacy"><span class="secno">7. </span><span class="content">Privacy Considerations</span><a class="self-link" href="#privacy"></a></h2>
 
-
+  
     <h3 class="heading settled" data-level="7.1" id="user-controls"><span class="secno">7.1. </span><span class="content">User Controls</span><a class="self-link" href="#user-controls"></a></h3>
 
 
@@ -1337,14 +1337,14 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
 
 
    <section>
-
+  
     <h2 class="heading settled" data-level="8" id="acknowledgements"><span class="secno">8. </span><span class="content">Acknowledgements</span><a class="self-link" href="#acknowledgements"></a></h2>
 
 
     <p>This specification is based in large part on Adam Barth and Jochen Eisinger’s
   <a href="http://wiki.whatwg.org/wiki/Meta_referrer">Meta referrer</a>
   document.</p>
-</section>
+</section> 
 
 </main>
 
@@ -1353,7 +1353,7 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
 
   <h3 class="no-ref no-num heading settled" id="conventions"><span class="content">Document conventions</span><a class="self-link" href="#conventions"></a></h3>
 
-
+    
   <p>Conformance requirements are expressed with a combination of
     descriptive assertions and RFC 2119 terminology. The key words "MUST",
     "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT",
@@ -1366,20 +1366,20 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
   <p>All of the text of this specification is normative except sections
     explicitly marked as non-normative, examples, and notes. <a data-link-type="biblio" href="#biblio-rfc2119">[RFC2119]</a></p>
 
-
+    
   <p>Examples in this specification are introduced with the words "for example"
     or are set apart from the normative text with <code>class="example"</code>,
     like this:
 
     </p>
   <div class="example">
-
+        
    <p>This is an example of an informative example.</p>
-
-
+   
+    
   </div>
 
-
+    
   <p>Informative notes begin with the word "Note" and are set apart from the
     normative text with <code>class="note"</code>, like this:
 
@@ -1389,13 +1389,13 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
 
   <h3 class="no-ref no-num heading settled" id="conformant-algorithms"><span class="content">Conformant Algorithms</span><a class="self-link" href="#conformant-algorithms"></a></h3>
 
-
+    
   <p>Requirements phrased in the imperative as part of algorithms (such as
     "strip any leading space characters" or "return false and abort these
     steps") are to be interpreted with the meaning of the key word ("must",
     "should", "may", etc) used in introducing the algorithm.</p>
 
-
+    
   <p>Conformance requirements phrased as algorithms or specific steps can be
     implemented in any manner, so long as the end result is equivalent. In
     particular, the algorithms defined in this specification are intended to
@@ -1405,11 +1405,11 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
 
   <h3 class="no-ref no-num heading settled" id="conformance-classes"><span class="content">Conformance Classes</span><a class="self-link" href="#conformance-classes"></a></h3>
 
-
+    
   <p>A <dfn data-dfn-type="dfn" data-noexport="" id="conformant-user-agent">conformant user agent<a class="self-link" href="#conformant-user-agent"></a></dfn> must implement all the requirements
     listed in this specification that are applicable to user agents.</p>
 
-
+    
   <p>A <dfn data-dfn-type="dfn" data-noexport="" id="conformant-server">conformant server<a class="self-link" href="#conformant-server"></a></dfn> must implement all the requirements listed
     in this specification that are applicable to servers.</p>
 

--- a/specs/referrer-policy/index.src.html
+++ b/specs/referrer-policy/index.src.html
@@ -359,7 +359,7 @@ spec: RFC7231; urlPrefix: https://tools.ietf.org/html/rfc7231
 <section>
   <h2 id="referrer-policy-delivery">Referrer Policy Delivery</h2>
 
-  A <a>settings object</a>'s <a>referrer policy</a> is deliveredin one of four
+  A <a>settings object</a>'s <a>referrer policy</a> is delivered in one of four
   ways:
 
   <ul>
@@ -678,7 +678,7 @@ spec: RFC7231; urlPrefix: https://tools.ietf.org/html/rfc7231
       <ol>
         <li>
           If <var>environment</var> is a <a>document environment</a>:
-          
+
           <ol>
             <li>
               Let <var>document</var> be the {{Document}} object of the
@@ -704,7 +704,7 @@ spec: RFC7231; urlPrefix: https://tools.ietf.org/html/rfc7231
         </li>
         <li>
           If <var>document</var> is set, execute the following steps:
-        
+
           <ol>
             <li>
               If <var>document</var>'s <a>origin</a> is not a scheme/host/port
@@ -904,4 +904,4 @@ spec: RFC7231; urlPrefix: https://tools.ietf.org/html/rfc7231
   This specification is based in large part on Adam Barth and Jochen Eisinger's
   <a href="http://wiki.whatwg.org/wiki/Meta_referrer">Meta referrer</a>
   document.
-</section> 
+</section>


### PR DESCRIPTION
Typo fix: s/deliveredin/delivered in/
Removed trailing spaces.

I will also attempt to fix any other typos I notice.

@mikewest, @jeisinger 