### PR TITLE
Mixed content algorithms unaffected by SRI

### DIFF
--- a/specs/subresourceintegrity/index.html
+++ b/specs/subresourceintegrity/index.html
@@ -261,13 +261,12 @@ executing a cryptographic hash function on an arbitrary block of data.</p>
     <p>The term <dfn>origin</dfn> is defined in the Origin specification.
 [[!RFC6454]]</p>
 
-    <p>The terms <dfn>privileged document</dfn>, <dfn>unprivileged document</dfn>, and
-<dfn>privileged context</dfn> are defined in <a href="https://w3c.github.io/webappsec/specs/powerfulfeatures/#terms">section 2 of the Privileged
-Contexts</a> specification. An example of a privileged document is a
-document loaded over HTTPS. An example of an unprivileged document and an
-unprivileged context are a document loaded over HTTP.</p>
+    <p>The terms <dfn>secure document</dfn> and
+<dfn>secure context</dfn> are defined in <a href="https://w3c.github.io/webappsec/specs/powerfulfeatures/#terms">section 2 of the Secure
+Contexts</a> specification. An example of a secure document is a
+document loaded over HTTPS. A counterexample is a document loaded over HTTP.</p>
 
-    <p>A <dfn>potentially secure origin</dfn> is defined in <a href="https://www.w3.org/TR/mixed-content/#potentially-secure-origin">section 2 of the Mixed
+    <p>A <dfn>potentially secure origin</dfn> is defined in <a href="http://www.w3.org/TR/mixed-content/#algorithms">section 2 of the Mixed
 Content</a> specification. An example of a potentially secure origin
 is an origin whose scheme component is <code>HTTPS</code>.</p>
 
@@ -435,15 +434,15 @@ globally unique identifiers for each file URI. This means that
 resources accessed over a <code>file</code> scheme URL are unlikely to be
 eligible for integrity checks.</p>
 
-      <p>One should note that being a <a href="#dfn-privileged-document">privileged document</a> (e.g. a document delivered
+      <p>One should note that being a <a href="#dfn-secure-document">secure document</a> (e.g. a document delivered
 over HTTPS) is not necessary for the use of integrity validation. Because
 resource integrity is only an application level security tool, and it does not
-change the security state of the user agent, a privileged document is
-unnecessary. However, if integrity is used in an <a href="#dfn-unprivileged-document">unprivileged document</a> (e.g.
+change the security state of the user agent, a <a href="#dfn-secure-document">secure document</a> is
+unnecessary. However, if integrity is used in other than a <a href="#dfn-secure-document">secure document</a> (e.g.
 a document delivered over HTTP), authors should be aware that the integrity
 provides <em>no security guarantees at all</em>. For this reason, authors should
 only deliver integrity metadata on a <a href="#dfn-potentially-secure-origin">potentially secure origin</a>.  See
-<a href="#unprivileged-contexts-remain-unprivileged-1">Unprivileged contexts remain unprivileged</a> for more discussion.</p>
+<a href="#non-secure-contexts-remain-non-secure-1">Non-secure contexts remain non-secure</a> for more discussion.</p>
 
       <p>Certain HTTP headers can also change the way the resource behaves in
 ways which integrity checking cannot account for. If the resource
@@ -831,18 +830,23 @@ Fetch</a>” section).</p>
   <h2 id="security-considerations">Security Considerations</h2>
 
   <section>
-    <h3 id="unprivileged-contexts-remain-unprivileged">Unprivileged contexts remain unprivileged</h3>
+    <h3 id="non-secure-contexts-remain-non-secure">Non-secure contexts remain non-secure</h3>
 
-    <p><a href="#dfn-integrity-metadata">Integrity metadata</a> delivered to an <a href="#dfn-unprivileged-context">unprivileged context</a>, such as an
-<a href="#dfn-unprivileged-document">unprivileged document</a>, only protects an origin against a compromise of the
+    <p><a href="#dfn-integrity-metadata">Integrity metadata</a> delivered to a context that is not a <a href="#dfn-secure-context">secure context</a>,
+such as an only protects an origin against a compromise of the
 server where an external resources is hosted. Network attackers can alter the
 digest in-flight (or remove it entirely, or do absolutely anything else to the
 document), just as they could alter the resource the hash is meant to validate.
-Thus, authors SHOULD deliver integrity metadata only to a <a href="#dfn-privileged-document">privileged
+Thus, authors SHOULD deliver integrity metadata only to a <a href="#dfn-secure-document">secure
 document</a>. See also <a href="https://w3ctag.github.io/web-https/">securing the web</a>.</p>
 
+    <p>Similarly, since integrity checks do not provide any privacy guarantees,
+<a href="#dfn-integrity-metadata">Integrity metadata</a> MUST NOT affect the return values of the Mixed Content
+algorithms as defined in <a href="http://www.w3.org/TR/mixed-content/#algorithms">section 5 of the Mixed Content</a>
+specification.</p>
+
   </section>
-  <!-- /Security::Insecure channels -->
+  <!-- /Security::Non-secure contexts remain non-secure -->
 
   <section>
     <h3 id="hash-collision-attacks">Hash collision attacks</h3>

--- a/specs/subresourceintegrity/spec.markdown
+++ b/specs/subresourceintegrity/spec.markdown
@@ -679,8 +679,14 @@ document), just as they could alter the resource the hash is meant to validate.
 Thus, authors SHOULD deliver integrity metadata only to a [secure
 document][]. See also [securing the web][].
 
+Similarly, since integrity checks do not provide any privacy guarantees,
+[Integrity metadata][] MUST NOT affect the return values of the Mixed Content
+algorithms as defined in [section 5 of the Mixed Content][mixedcontent]
+specification.
+
 [Securing the Web]: https://w3ctag.github.io/web-https/
-</section><!-- /Security::Insecure channels -->
+[mixedcontent]: http://www.w3.org/TR/mixed-content/#algorithms
+</section><!-- /Security::Non-secure contexts remain non-secure -->
 
 <section>
 ### Hash collision attacks


### PR DESCRIPTION
As mentioned in https://lists.w3.org/Archives/Public/public-webappsec/2015May/0065.html, we should probably have a note making our conversations about mixed content explicit. This adds a brief sentence stating that integrity doesn't affect the Mixed Content algorithms. /cc @devd @fmarier @mozfreddyb 