### PR TITLE
Point to right chunk of CSP ABNF for hash syntax

### DIFF
--- a/specs/subresourceintegrity/spec.markdown
+++ b/specs/subresourceintegrity/spec.markdown
@@ -205,7 +205,7 @@ At the moment, no options are defined. However, future versions of
 the spec may define options, such as MIME types [[!MIMETYPE]].
 </div>
 
-This metadata MUST be encoded in the same format as the `hash-source`
+This metadata MUST be encoded in the same format as the `hash-algo`
 in [section 4.2 of the Content Security Policy Level 2 specification][csp2-section42].
 
 For example, given a script resource containing only the string "alert('Hello, world.');",

--- a/specs/subresourceintegrity/spec.markdown
+++ b/specs/subresourceintegrity/spec.markdown
@@ -205,7 +205,7 @@ At the moment, no options are defined. However, future versions of
 the spec may define options, such as MIME types [[!MIMETYPE]].
 </div>
 
-This metadata MUST be encoded in the same format as the `hash-algo`
+This metadata MUST be encoded in the same format as the hash-source
 in [section 4.2 of the Content Security Policy Level 2 specification][csp2-section42].
 
 For example, given a script resource containing only the string "alert('Hello, world.');",

--- a/specs/subresourceintegrity/spec.markdown
+++ b/specs/subresourceintegrity/spec.markdown
@@ -205,7 +205,7 @@ At the moment, no options are defined. However, future versions of
 the spec may define options, such as MIME types [[!MIMETYPE]].
 </div>
 
-This metadata MUST be encoded in the same format as the hash-source
+This metadata MUST be encoded in the same format as the `hash-source` (without the single quotes)
 in [section 4.2 of the Content Security Policy Level 2 specification][csp2-section42].
 
 For example, given a script resource containing only the string "alert('Hello, world.');",


### PR DESCRIPTION
In https://w3c.github.io/webappsec/specs/content-security-policy/ hash-src is defined with quotes and we don't use that.