### PR TITLE
CSP: fix broken hash value in 7.15.2

### DIFF
--- a/specs/content-security-policy/index.src.html
+++ b/specs/content-security-policy/index.src.html
@@ -3382,7 +3382,7 @@ spec: SHA2; urlPrefix: http://csrc.nist.gov/groups/STM/cavp/documents/shs/sha256
       If the server sent the following header:
 
       <pre>
-        Content-Security-Policy: <a>script-src</a> 'sha512-YWIzOWNiNzJjNDRlYzc4MTgwMDhmZDlkOWI0NTAyMjgyY2MyMWJlMWUyNjc1ODJlYWJhNjU5MGU4NmZmNGU3OAo='
+        Content-Security-Policy: <a>script-src</a> 'sha256-qznLcsROx4GACP2dm0UCKCzCG+HiZ1guq6ZZDob/Tng='
       </pre>
 
       Then the following script tag would result in script execution:


### PR DESCRIPTION
Two issues here: the hash algorithm should be sha256, and the hash itself should be base64 encoded. The current example uses a base64 encoding of the hex encoding of the hash.