### PR TITLE
Revert "getprioritizedhashfunction is not exposed to webapps"

### DIFF
--- a/specs/subresourceintegrity/spec.markdown
+++ b/specs/subresourceintegrity/spec.markdown
@@ -285,9 +285,6 @@ collision-resistant.  For example, `getPrioritizedHashFunction('sha256',
 'sha512')` would return `'sha512'` and `getPrioritizedHashFunction('sha256',
 'sha256')` would return the empty string.
 
-The `getPrioritizedHashFunction` implementation is vendor specific, and the interface 
-provided is not exposed to the application.
-
 </section><!-- /Framework::Cryptographic hash functions::Priority -->
 
 </section><!-- /Framework::Cryptographic hash functions -->


### PR DESCRIPTION
Reverts w3c/webappsec#369