### PR TITLE
Fix typo: s/An resource's origin/A resource's origin/

### DIFF
--- a/specs/mixedcontent/index.src.html
+++ b/specs/mixedcontent/index.src.html
@@ -248,7 +248,7 @@ type: element-attr
       </dfn>
     </dt>
     <dd>
-      An resource's origin is said to be <strong>insecure</strong> if it is
+      A resource's origin is said to be <strong>insecure</strong> if it is
       either <a><i lang="la">a priori</i> insecure</a>, or the user agent discovers
       only after performing a TLS-handshake that the TLS-protection offered
       is <a>deprecated</a>.


### PR DESCRIPTION
Small typo fix. 

Also checked here: http://www.gingersoftware.com/grammarcheck

@mikewest