### PR TITLE
Fixed broken syntax in template (missing ':' after mailto).

### DIFF
--- a/specs/subresourceintegrity/index.html
+++ b/specs/subresourceintegrity/index.html
@@ -23,10 +23,10 @@
         // editors, add as many as you like
         // only "name" is required
         editors:  [
-            { name: "Devdatta Akhawe", url: "mailto:dev.akhawe@gmail.com", company: "Dropbox, Inc.", companyURL: "https://www.dropbox.com/"},
-            { name: "Francois Marier", url: "mailto:francois@mozilla.com", company: "Mozilla", companyURL: "https://www.mozilla.org/" },
-            { name: "Frederik Braun", url: "mailto:fbraun@mozilla.com", company: "Mozilla", companyURL: "https://www.mozilla.org/", w3cid: 68466 },
-            { name: "Joel Weinberger", url: "mailto:jww@google.com", company: "Google, Inc.", companyURL: "https://google.com/" },
+            { name: "Devdatta Akhawe", mailto: "dev.akhawe@gmail.com", company: "Dropbox, Inc.", companyURL: "https://www.dropbox.com/"},
+            { name: "Francois Marier", mailto: "francois@mozilla.com", company: "Mozilla", companyURL: "https://www.mozilla.org/" },
+            { name: "Frederik Braun", url: "https://frederik-braun.com/", mailto: "fbraun@mozilla.com", company: "Mozilla", companyURL: "https://www.mozilla.org/", w3cid: 68466 },
+            { name: "Joel Weinberger", mailto: "jww@google.com", company: "Google, Inc.", companyURL: "https://google.com/" },
         ],
 
         otherLinks: [{

--- a/specs/subresourceintegrity/template.erb
+++ b/specs/subresourceintegrity/template.erb
@@ -23,10 +23,10 @@
         // editors, add as many as you like
         // only "name" is required
         editors:  [
-            { name: "Devdatta Akhawe", mailto "dev.akhawe@gmail.com", company: "Dropbox, Inc.", companyURL: "https://www.dropbox.com/"},
+            { name: "Devdatta Akhawe", mailto: "dev.akhawe@gmail.com", company: "Dropbox, Inc.", companyURL: "https://www.dropbox.com/"},
             { name: "Francois Marier", mailto: "francois@mozilla.com", company: "Mozilla", companyURL: "https://www.mozilla.org/" },
             { name: "Frederik Braun", url: "https://frederik-braun.com/", mailto: "fbraun@mozilla.com", company: "Mozilla", companyURL: "https://www.mozilla.org/", w3cid: 68466 },
-            { name: "Joel Weinberger", mailto "jww@google.com", company: "Google, Inc.", companyURL: "https://google.com/" },
+            { name: "Joel Weinberger", mailto: "jww@google.com", company: "Google, Inc.", companyURL: "https://google.com/" },
         ],
 
         otherLinks: [{


### PR DESCRIPTION
This is a straightforward change for a syntax error in the template file, so I'm going to go ahead and merge.