### PR TITLE
SRI: no need to add "Cache-Control: no-transform"

### DIFF
--- a/specs/subresourceintegrity/index.html
+++ b/specs/subresourceintegrity/index.html
@@ -625,15 +625,6 @@ the <var>request</var>, set <var>response</var> to a
         </ol>
       </li>
       <li>
-        <p>Perform the following steps before executing both the “<a href="https://fetch.spec.whatwg.org/#basic-fetch">basic fetch</a>” and
-“<a href="https://fetch.spec.whatwg.org/#cors-fetch-with-preflight">CORS fetch with preflight</a>” algorithms:</p>
-
-        <ol>
-          <li>If <var>request</var>’s integrity metadata is a non-empty string,
-include a <code>Cache-Control</code> header whose value is “no-transform”.</li>
-        </ol>
-      </li>
-      <li>
         <p>Add the following to the <a href="https://fetch.spec.whatwg.org/#request">Request class definition</a>:</p>
 
         <ol>
@@ -809,12 +800,11 @@ with those resources stays in sync with the new content. One option
 is to ensure that the <a href="#dfn-integrity-metadata">integrity metadata</a> associated with
 resources is updated along with the resource itself. Another
 would be simply to deliver only the canonical version of resources
-for which a page author has requested integrity verification. To
-support this latter option, user agents MUST send a
-<a href="http://tools.ietf.org/html/rfc7234#section-5.2"><code>Cache-Control</code></a> header with a value of
-<a href="http://tools.ietf.org/html/rfc7234#section-5.2.1.6"><code>no-transform</code></a> when requesting a resource with
-associated integrity metadata (see item 3 in the “<a href="#modifications-to-fetch">Modifications to
-Fetch</a>” section).</p>
+for which a page author has requested integrity verification.</p>
+
+  <p>To help inform intermediate servers, those serving the resources SHOULD
+send along with the resource a <a href="http://tools.ietf.org/html/rfc7234#section-5.2"><code>Cache-Control</code></a> header
+with a value of <a href="http://tools.ietf.org/html/rfc7234#section-5.2.1.6"><code>no-transform</code></a>.</p>
 
 </section>
 <!-- /Implementation -->

--- a/specs/subresourceintegrity/spec.markdown
+++ b/specs/subresourceintegrity/spec.markdown
@@ -382,7 +382,6 @@ the user agent.
     <var>result</var>.
 
 [split-on-spaces]: http://www.w3.org/TR/html5/infrastructure.html#split-a-string-on-spaces
-[integrity metadata]: #dfn-integrity-metadata
 </section><!-- Algorithms::parse -->
 <section>
 #### Get the strongest metadata from <var>set</var>.

--- a/specs/subresourceintegrity/spec.markdown
+++ b/specs/subresourceintegrity/spec.markdown
@@ -605,6 +605,7 @@ from a CDN, perhaps from a secondary, trusted, but slower source) can catch this
 failed resource with a different one.
 {:.note}
 
+[Modifications to Fetch]: #modifications-to-fetch
 </section>
 
 <section>

--- a/specs/subresourceintegrity/spec.markdown
+++ b/specs/subresourceintegrity/spec.markdown
@@ -487,13 +487,7 @@ to enable the rest of this specification's work [[!FETCH]]:
             the <var>request</var>, set <var>response</var> to a
             [network error][].
 
-3.  Perform the following steps before executing both the "[basic fetch][]" and
-    "[CORS fetch with preflight][]" algorithms:
-
-    1.  If <var>request</var>'s integrity metadata is a non-empty string,
-        include a `Cache-Control` header whose value is "no-transform".
-
-4. Add the following to the [Request class definition][fetch-request-api]:
+3. Add the following to the [Request class definition][fetch-request-api]:
 
     1. Add the following attribute to the <code>Request</code> class after the
        <code>redirect</code> attribute as follows:
@@ -664,16 +658,8 @@ with those resources stays in sync with the new content. One option
 is to ensure that the [integrity metadata][] associated with
 resources is updated along with the resource itself. Another
 would be simply to deliver only the canonical version of resources
-for which a page author has requested integrity verification. To
-support this latter option, user agents MUST send a
-[`Cache-Control`][cachecontrol] header with a value of
-[`no-transform`][notransform] when requesting a resource with
-associated integrity metadata (see item 3 in the "[Modifications to
-Fetch][]" section).
+for which a page author has requested integrity verification.
 
-[cachecontrol]: http://tools.ietf.org/html/rfc7234#section-5.2
-[notransform]: http://tools.ietf.org/html/rfc7234#section-5.2.1.6
-[Modifications to Fetch]: #modifications-to-fetch
 </section><!-- /Implementation -->
 
 <section>

--- a/specs/subresourceintegrity/spec.markdown
+++ b/specs/subresourceintegrity/spec.markdown
@@ -660,6 +660,13 @@ resources is updated along with the resource itself. Another
 would be simply to deliver only the canonical version of resources
 for which a page author has requested integrity verification.
 
+To help inform intermediate servers, those serving the resources SHOULD
+send along with the resource a [`Cache-Control`][cachecontrol] header
+with a value of [`no-transform`][notransform].
+
+[cachecontrol]: http://tools.ietf.org/html/rfc7234#section-5.2
+[notransform]: http://tools.ietf.org/html/rfc7234#section-5.2.1.6
+
 </section><!-- /Implementation -->
 
 <section>


### PR DESCRIPTION
This directive only applies to the request it's in. It doesn't
apply to the response, which was the whole point of us adding that
header.

https://github.com/w3c/webappsec/issues/217#issuecomment-112223659