### PR TITLE
Lowercase 'must' regarding priority of hash functions

### DIFF
--- a/specs/subresourceintegrity/index.html
+++ b/specs/subresourceintegrity/index.html
@@ -399,7 +399,7 @@ stronger hash functions as they become available.</p>
     <section>
       <h4 id="priority">Priority</h4>
 
-      <p>User agents MUST provide a mechanism of determining the relative priority of two
+      <p>User agents must provide a mechanism of determining the relative priority of two
 hash functions and return the empty string if the priority is equal. That is, if
 a user agent implemented a function like <dfn>getPrioritizedHashFunction(a,
 b)</dfn> it would return the hash function the user agent considers the most
@@ -891,7 +891,8 @@ some side-channels will likely be difficult to avoid.</p>
 Markham’s <a href="http://www.gerv.net/security/link-fingerprints/">Link Fingerprints</a> concept, as well as WHATWG’s <a href="https://wiki.whatwg.org/wiki/Link_Hashes">Link Hashes</a>.</p>
 
   <p>A special thanks to Mike West of Google, Inc. for his invaluable contributions
-to the initial version of this spec.</p>
+to the initial version of this spec. Additonally, Brad Hill, Anne van Kesteren, Mark Nottingham, 
+Dan Veditz, Eduardo Vela, Tanvi Vyas, and Michal Zalewski provided invaluable feedback.</p>
 
 </section>
 

--- a/specs/subresourceintegrity/spec.markdown
+++ b/specs/subresourceintegrity/spec.markdown
@@ -277,7 +277,7 @@ stronger hash functions as they become available.
 <section>
 #### Priority
 
-User agents MUST provide a mechanism of determining the relative priority of two
+User agents must provide a mechanism of determining the relative priority of two
 hash functions and return the empty string if the priority is equal. That is, if
 a user agent implemented a function like <dfn>getPrioritizedHashFunction(a,
 b)</dfn> it would return the hash function the user agent considers the most


### PR DESCRIPTION
As per an offline conversation, it feels odd to upper-case 'MUST' this statement since it's effectively an implementation detail, and not related to anything externally facing. Thus, it makes more sense to lowercase this. Confirmation from @devd, @fmarier, or @mozfreddyb?