### PR TITLE
Fixing some markup errors in the charter

### DIFF
--- a/admin/webappsec-charter-2015.html
+++ b/admin/webappsec-charter-2015.html
@@ -207,7 +207,7 @@
         </dd>
     
         <dt>
-          <b><a href="http://www.w3.org/TR/mixed-content/">Mixed Content</a> (LCWD)</a></b>
+          <b><a href="http://www.w3.org/TR/mixed-content/">Mixed Content</a> (LCWD)</b>
         </dt>
 
         <dd> <p>A recommendation for dealing with
@@ -234,7 +234,7 @@
 
 
 				<dt>
-          <b><a href="http://www.w3.org/TR/powerful-features/">Privileged Contexts</a> (FPWD)</a></b>
+          <b><a href="http://www.w3.org/TR/powerful-features/">Privileged Contexts</a> (FPWD)</b>
         </dt>
 
         <dd> <p>A recommendation for dealing with features which self-designate as requiring
@@ -247,7 +247,7 @@
         </dd>
 
         <dt>
-          <b><a href="http://www.w3.org/TR/SRI/">Subresource Integrity</a> (FPWD)</a></b>
+          <b><a href="http://www.w3.org/TR/SRI/">Subresource Integrity</a> (FPWD)</b>
         </dt>
 
         <dd> <p>A recommendation for uniquely identifying 
@@ -266,7 +266,7 @@
         </dd>
         
         <dt>
-          <b><a href="http://www.w3.org/TR/referrer-policy/">Referrer Policy</a> (FPWD)</a></b>
+          <b><a href="http://www.w3.org/TR/referrer-policy/">Referrer Policy</a> (FPWD)</b>
         </dt>
 
         <dd> <p>A recommendation for a header and meta tag allowing resource authors to specify
@@ -537,7 +537,7 @@
             review some of its specifications.</dd>
             <dt><a href="http://www.w3.org/WAI/PF/">Protocols and Formats Working Group</a></dt>
            <dd>The WG may ask the PFWG to review some of its specifications for potential accessibility issues. </dd>
-	<dt><a href="http://www.w3.org/2008/webapps/">Web Applications Working Group</a>/dt>
+	<dt><a href="http://www.w3.org/2008/webapps/">Web Applications Working Group</a></dt>
 	<dd>The WG may coordinate with WebApps around API design.</dd>
 	<dt><a href="http://www.w3.org/2011/tracking-protection/">Tracking Protection Working Group</a></dt>
 	<dd>The WG may ask TPWG for review of deliverables including Referrer Policy.</dd>


### PR DESCRIPTION
The `Web Applications Working Group/dt>` markup was visible for me in chrome... conditionally (which was odd).

However anyway fixing some broken bits of HTML however still wouldn't validate etc.