### PR TITLE
SRI: Changing rel value to keyword for matching stylesheets

### DIFF
--- a/specs/subresourceintegrity/index.html
+++ b/specs/subresourceintegrity/index.html
@@ -759,7 +759,7 @@ failed resource with a different one.</p>
       <h6 id="the-link-element-for-stylesheets">The <code>link</code> element for stylesheets</h6>
 
       <p>Whenever a user agent attempts to <a href="http://www.w3.org/TR/html5/document-metadata.html#concept-link-obtain">obtain a resource</a> pointed to by a
-<code>link</code> element that has a <code>rel</code> attribute with the value of <code>stylesheet</code>,
+<code>link</code> element that has a <code>rel</code> attribute with the keyword of <code>stylesheet</code>,
 modify step 4 to read:</p>
 
       <p>Do a potentially CORS-enabled fetch of the resulting absolute URL, with the

--- a/specs/subresourceintegrity/spec.markdown
+++ b/specs/subresourceintegrity/spec.markdown
@@ -614,7 +614,7 @@ failed resource with a different one.
 ###### The `link` element for stylesheets
 
 Whenever a user agent attempts to [obtain a resource][] pointed to by a
-`link` element that has a `rel` attribute with the value of `stylesheet`,
+`link` element that has a `rel` attribute with the keyword of `stylesheet`,
 modify step 4 to read:
 
 Do a potentially CORS-enabled fetch of the resulting absolute URL, with the


### PR DESCRIPTION
As rel can contain multiple values using the word keyword would allow for different attributes here.