### PR TITLE
rename 'referrer' attribute to 'referrerpolicy', make rel=noreferrer take priority

### DIFF
--- a/specs/referrer-policy/index.html
+++ b/specs/referrer-policy/index.html
@@ -70,8 +70,8 @@
   
    <h1 class="p-name no-ref" id="title">Referrer Policy</h1>
   
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft
-    <time class="dt-updated" datetime="2015-05-11">11 May 2015</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft,
+    <time class="dt-updated" datetime="2015-07-22">22 July 2015</time></span></h2>
   
    <div data-fill-with="spec-metadata">
     <dl>
@@ -82,7 +82,7 @@
      <dt>Version History:
      <dd><a href="https://github.com/w3c/webappsec/commits/master/specs/referrer-policy/index.src.html">https://github.com/w3c/webappsec/commits/master/specs/referrer-policy/index.src.html</a>
      <dt>Feedback:
-     <dd><span><a href="mailto:public-webappsec@w3.org?subject=%5BREFERRER%5D%20feedback">public-webappsec@w3.org</a> with subject line “<kbd>[REFERRER] <var>… message topic …</var></kbd>” (<a href="http://lists.w3.org/Archives/Public/public-webappsec/" rel="discussion">archives</a>)</span>
+     <dd><span><a href="mailto:public-webappsec@w3.org?subject=%5BREFERRER%5D%20YOUR%20TOPIC%20HERE">public-webappsec@w3.org</a> with subject line “<kbd>[REFERRER] <var>… message topic …</var></kbd>” (<a href="http://lists.w3.org/Archives/Public/public-webappsec/" rel="discussion">archives</a>)</span>
      <dt>Issue Tracking:
      <dd><a href="#issues-index">Inline In Spec</a>
      <dt class="editor">Editors:
@@ -184,7 +184,7 @@
        </ul>
       <li><a href="#referrer-policy-delivery-meta"><span class="secno">4.2</span> <span class="content">Delivery via <code><span>meta</span></code></span></a>
       <li><a href="#referrer-policy-delivery-referrer-attribute"><span class="secno">4.3</span> <span class="content">Delivery
-  via a <code>referrer</code> attribute</span></a>
+  via a <code>referrerpolicy</code> attribute</span></a>
       <li><a href="#referrer-policy-delivery-implicit"><span class="secno">4.4</span> <span class="content">Implicit Delivery</span></a>
        <ul class="toc">
         <li><a href="#referrer-policy-delivery-implicit-nested"><span class="secno">4.4.1</span> <span class="content">
@@ -318,9 +318,7 @@
       <p>If no referrer policy is explicitly set for a <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#settings-object">settings object</a>,
       then the value of the property is <code>null</code>. Otherwise, the value
       is whatever has been explicitly set, as explained in the
-      <a href="#set-referrer-policy">§6.1 
-    Set environment’s referrer policy to policy
-  </a> algorithm.</p>
+      <a href="#set-referrer-policy">§6.1 Set environment’s referrer policy to policy</a> algorithm.</p>
       
     
      
@@ -548,12 +546,12 @@
      
     
      <li>
-      Via a <code><a data-link-type="element" href="http://www.w3.org/TR/html5/document-metadata.html#the-meta-element">meta</a></code> element with a <code><a data-link-type="element-attr" href="http://www.w3.org/TR/html5/document-metadata.html#attr-meta-name">name</a></code> of <code>referrer</code>.
+      Via a <code><a data-link-type="element" href="http://www.w3.org/TR/html5/document-metadata.html#the-meta-element">meta</a></code> element with a <code><a data-link-type="element-attr" href="http://www.w3.org/TR/html5/document-metadata.html#attr-meta-name">name</a></code> of <code>referrerpolicy</code>.
     
      
     
      <li>
-      Via a <code>referrer</code> attribute on an <code><a data-link-type="element" href="http://www.w3.org/TR/html5/text-level-semantics.html#the-a-element">a</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/#the-area-element">area</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/#the-img-element">img</a></code>
+      Via a <code>referrerpolicy</code> attribute on an <code><a data-link-type="element" href="http://www.w3.org/TR/html5/text-level-semantics.html#the-a-element">a</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-area-element">area</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">img</a></code>
       or <code><a data-link-type="element" href="http://www.w3.org/TR/html5/embedded-content-0.html#the-iframe-element">iframe</a></code> element.
     
      
@@ -588,12 +586,8 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
     <p>When
   <a href="https://w3c.github.io/webappsec/specs/content-security-policy/#enforce">enforcing</a>
   the <code>referrer</code> directive, the user agent MUST execute
-  <a href="#set-referrer-policy">§6.1 
-    Set environment’s referrer policy to policy
-  </a> on the protected resource’s <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#incumbent-settings-object">incumbent settings
-  object</a>, using the result of executing <a href="#determine-policy-for-token">§6.4 
-    Determine token’s Policy
-  </a>
+  <a href="#set-referrer-policy">§6.1 Set environment’s referrer policy to policy</a> on the protected resource’s <a data-link-type="dfn" href="http://www.w3.org/TR/html5/webappapis.html#incumbent-settings-object">incumbent settings
+  object</a>, using the result of executing <a href="#determine-policy-for-token">§6.4 Determine token’s Policy</a>
   on the <code>referrer</code> directive’s value.</p>
 
   
@@ -695,7 +689,7 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
       <ol>
         
        <li>
-          If the Document’s <code><a data-link-type="element" href="https://html.spec.whatwg.org/#the-head-element">head</a></code> element is not an ancestor of the <code><a data-link-type="element" href="http://www.w3.org/TR/html5/document-metadata.html#the-meta-element">meta</a></code>
+          If the Document’s <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-head-element">head</a></code> element is not an ancestor of the <code><a data-link-type="element" href="http://www.w3.org/TR/html5/document-metadata.html#the-meta-element">meta</a></code>
           element, abort these steps.
         
        
@@ -732,17 +726,13 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
         
        <li>
           Let <var>policy</var> be the result of executing the
-          <a href="#determine-policy-for-token">§6.4 
-    Determine token’s Policy
-  </a> algorithm on <var>meta-value</var>.
+          <a href="#determine-policy-for-token">§6.4 Determine token’s Policy</a> algorithm on <var>meta-value</var>.
         
        
 
         
        <li>
-          Execute the <a href="#set-referrer-policy">§6.1 
-    Set environment’s referrer policy to policy
-  </a> algorithm on
+          Execute the <a href="#set-referrer-policy">§6.1 Set environment’s referrer policy to policy</a> algorithm on
           <var>environment</var> using <var>policy</var>, if <var>policy</var>
           is not <code>null</code>.
         
@@ -771,20 +761,20 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
 
   
     <h3 class="heading settled" data-level="4.3" id="referrer-policy-delivery-referrer-attribute"><span class="secno">4.3. </span><span class="content">Delivery
-  via a <code>referrer</code> attribute</span><a class="self-link" href="#referrer-policy-delivery-referrer-attribute"></a></h3>
+  via a <code>referrerpolicy</code> attribute</span><a class="self-link" href="#referrer-policy-delivery-referrer-attribute"></a></h3>
 
 
-    <p>A referrer policy may be set when a <code>referrer</code> attribute is
-  added to an <code><a data-link-type="element" href="http://www.w3.org/TR/html5/text-level-semantics.html#the-a-element">a</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/#the-area-element">area</a></code>,
-  <code><a data-link-type="element" href="https://html.spec.whatwg.org/#the-img-element">img</a></code> or <code><a data-link-type="element" href="http://www.w3.org/TR/html5/embedded-content-0.html#the-iframe-element">iframe</a></code>
+    <p>A referrer policy may be set when a <code>referrerpolicy</code> attribute is
+  added to an <code><a data-link-type="element" href="http://www.w3.org/TR/html5/text-level-semantics.html#the-a-element">a</a></code>, <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-area-element">area</a></code>,
+  <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">img</a></code> or <code><a data-link-type="element" href="http://www.w3.org/TR/html5/embedded-content-0.html#the-iframe-element">iframe</a></code>
   element, for example:</p>
 
   
-    <pre class="example" id="example-089cca85"><a class="self-link" href="#example-089cca85"></a>&lt;a href="http://example.com" referrer="origin">
+    <pre class="example" id="example-d7516db8"><a class="self-link" href="#example-d7516db8"></a>&lt;a href="http://example.com" referrerpolicy="origin">
 </pre>
 
 
-    <p>The following values for the <code>referrer</code> attribute are valid,
+    <p>The following values for the <code>referrerpolicy</code> attribute are valid,
   and map to the listed <a data-link-type="dfn" href="#referrer-policy">referrer policy</a> values:</p>
 
   
@@ -811,16 +801,16 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
     </dl>
 
 
-    <p>A policy delivered via a <code>referrer</code> attribute on an element
+    <p>A policy delivered via a <code>referrerpolicy</code> attribute on an element
   takes precedence over the policy defined for the whole document via CSP or
   a <a data-link-type="element" href="http://www.w3.org/TR/html5/document-metadata.html#the-meta-element">meta</a> element.</p>
 
 
-    <p class="issue" id="issue-4ec1eba2"><a class="self-link" href="#issue-4ec1eba2"></a>If an <code><a data-link-type="element" href="http://www.w3.org/TR/html5/text-level-semantics.html#the-a-element">a</a></code>
-  or <code><a data-link-type="element" href="https://html.spec.whatwg.org/#the-area-element">area</a></code> element includes both
-  a <code>referrer</code> attribute as well as
+    <p class="issue" id="issue-a2e997ff"><a class="self-link" href="#issue-a2e997ff"></a> If an <code><a data-link-type="element" href="http://www.w3.org/TR/html5/text-level-semantics.html#the-a-element">a</a></code>
+  or <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-area-element">area</a></code> element includes both
+  a <code>referrerpolicy</code> attribute as well as
   a <a href="https://html.spec.whatwg.org/#link-type-noreferrer"><code>noreferrer</code>
-  link type</a>, should the policy of the <code>referrer</code> attribute
+  link type</a>, should the policy of the <code>referrerpolicy</code> attribute
   take precedence over the link type, as suggested
   by <a href="https://lists.w3.org/Archives/Public/public-webappsec/2015Feb/0235.html">Martin
   Thomson</a>, or should we take the more conservative approach as suggested
@@ -861,9 +851,7 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
      
     
      <li>
-      Execute the <a href="#set-referrer-policy">§6.1 
-    Set environment’s referrer policy to policy
-  </a> algorithm on
+      Execute the <a href="#set-referrer-policy">§6.1 Set environment’s referrer policy to policy</a> algorithm on
       <var>environment</var> using <var>policy</var>, if <var>policy</var>
       is not <code>null</code>.
     
@@ -895,9 +883,7 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
      
     
      <li>
-      Execute the <a href="#set-referrer-policy">§6.1 
-    Set environment’s referrer policy to policy
-  </a> algorithm on
+      Execute the <a href="#set-referrer-policy">§6.1 Set environment’s referrer policy to policy</a> algorithm on
       <var>environment</var> using <var>policy</var>.
     
      
@@ -975,7 +961,7 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
   into this algorithm.</p>
 
 
-    <p class="issue" id="issue-2cf94c0c"><a class="self-link" href="#issue-2cf94c0c"></a>This algorithm needs to be modifed to take into account any local
+    <p class="issue" id="issue-2cf94c0c"><a class="self-link" href="#issue-2cf94c0c"></a> This algorithm needs to be modifed to take into account any local
   overrides via the referrer attribute on elements.</p>
 
   
@@ -1419,21 +1405,21 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
   <h2 class="no-num heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
   <h3 class="no-num heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
   <ul class="indexlist">
-   <li>conformant server, <a href="#conformant-server">Unnumbered section</a>
-   <li>conformant user agent, <a href="#conformant-user-agent">Unnumbered section</a>
-   <li>cross-origin, <a href="#cross_origin-request">2</a>
-   <li>cross-origin request, <a href="#cross_origin-request">2</a>
-   <li>No Referrer, <a href="#no-referrer">3.1</a>
-   <li>No Referrer When Downgrade, <a href="#no-referrer-when-downgrade">3.2</a>
-   <li>Origin Only, <a href="#origin-only">3.3</a>
-   <li>origin-only flag, <a href="#origin_only-flag">6.3</a>
-   <li>Origin When Cross-Origin, <a href="#origin-when-cross_origin">3.4</a>
-   <li>policy, <a href="#referrer-policy">2</a>
-   <li>referrer directive, <a href="#referrer-directive">4.1</a>
-   <li>referrer policy, <a href="#referrer-policy">2</a>
-   <li>same-origin, <a href="#same_origin-request">2</a>
-   <li>same-origin request, <a href="#same_origin-request">2</a>
-   <li>Unsafe URL, <a href="#unsafe-url">3.5</a></ul>
+   <li><a href="#conformant-server">conformant server</a><span>, in §Unnumbered section</span>
+   <li><a href="#conformant-user-agent">conformant user agent</a><span>, in §Unnumbered section</span>
+   <li><a href="#cross_origin-request">cross-origin</a><span>, in §2</span>
+   <li><a href="#cross_origin-request">cross-origin request</a><span>, in §2</span>
+   <li><a href="#no-referrer">No Referrer</a><span>, in §3.1</span>
+   <li><a href="#no-referrer-when-downgrade">No Referrer When Downgrade</a><span>, in §3.2</span>
+   <li><a href="#origin-only">Origin Only</a><span>, in §3.3</span>
+   <li><a href="#origin_only-flag">origin-only flag</a><span>, in §6.3</span>
+   <li><a href="#origin-when-cross_origin">Origin When Cross-Origin</a><span>, in §3.4</span>
+   <li><a href="#referrer-policy">policy</a><span>, in §2</span>
+   <li><a href="#referrer-directive">referrer directive</a><span>, in §4.1</span>
+   <li><a href="#referrer-policy">referrer policy</a><span>, in §2</span>
+   <li><a href="#same_origin-request">same-origin</a><span>, in §2</span>
+   <li><a href="#same_origin-request">same-origin request</a><span>, in §2</span>
+   <li><a href="#unsafe-url">Unsafe URL</a><span>, in §3.5</span></ul>
   <h3 class="no-num heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
   <ul class="indexlist">
    <li><a data-link-type="biblio" href="#biblio-dom">[dom]</a> defines the following terms:
@@ -1498,11 +1484,11 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
     <ul>
      <li><a href="http://www.w3.org/TR/2010/REC-wsc-ui-20100812/#typesoftls">tls-protected</a>
     </ul>
-   <li><a data-link-type="biblio" href="#biblio-html5">[html5]</a> defines the following terms:
+   <li><a data-link-type="biblio" href="#biblio-html">[HTML]</a> defines the following terms:
     <ul>
-     <li><a href="https://html.spec.whatwg.org/#the-area-element">area</a>
-     <li><a href="https://html.spec.whatwg.org/#the-head-element">head</a>
-     <li><a href="https://html.spec.whatwg.org/#the-img-element">img</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-area-element">area</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/semantics.html#the-head-element">head</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">img</a>
     </ul></ul>
   <h2 class="no-num heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
   <h3 class="no-num heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
@@ -1511,6 +1497,8 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
    <dd>Mike West; Adam Barth; Dan Veditz. <a href="https://w3c.github.io/webappsec/specs/content-security-policy/">Content Security Policy Level 2</a>. CR. URL: <a href="https://w3c.github.io/webappsec/specs/content-security-policy/">https://w3c.github.io/webappsec/specs/content-security-policy/</a>
    <dt id="biblio-fetch"><a class="self-link" href="#biblio-fetch"></a>[FETCH]
    <dd>Anne van Kesteren. <a href="https://fetch.spec.whatwg.org/">Fetch</a>. Living Standard. URL: <a href="https://fetch.spec.whatwg.org/">https://fetch.spec.whatwg.org/</a>
+   <dt id="biblio-html"><a class="self-link" href="#biblio-html"></a>[HTML]
+   <dd>Ian Hickson. <a href="https://html.spec.whatwg.org/multipage/">HTML Standard</a>. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
    <dt id="biblio-mix"><a class="self-link" href="#biblio-mix"></a>[MIX]
    <dd>Mike West. <a href="https://w3c.github.io/webappsec/specs/mixedcontent/">Mixed Content</a>. LCWD. URL: <a href="https://w3c.github.io/webappsec/specs/mixedcontent/">https://w3c.github.io/webappsec/specs/mixedcontent/</a>
    <dt id="biblio-rfc6454"><a class="self-link" href="#biblio-rfc6454"></a>[RFC6454]
@@ -1520,11 +1508,11 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
    <dt id="biblio-url"><a class="self-link" href="#biblio-url"></a>[URL]
    <dd>Anne van Kesteren. <a href="https://url.spec.whatwg.org/">URL</a>. Living Standard. URL: <a href="https://url.spec.whatwg.org/">https://url.spec.whatwg.org/</a>
    <dt id="biblio-dom"><a class="self-link" href="#biblio-dom"></a>[DOM]
-   <dd>Anne van Kesteren; et al. <a href="http://www.w3.org/TR/dom/">W3C DOM4</a>. 10 July 2014. LCWD. URL: <a href="http://www.w3.org/TR/dom/">http://www.w3.org/TR/dom/</a>
+   <dd>Anne van Kesteren; et al. <a href="http://www.w3.org/TR/dom/">W3C DOM4</a>. 18 June 2015. LCWD. URL: <a href="http://www.w3.org/TR/dom/">http://www.w3.org/TR/dom/</a>
    <dt id="biblio-html5"><a class="self-link" href="#biblio-html5"></a>[HTML5]
-   <dd>Robin Berjon; et al. <a href="http://www.w3.org/TR/html5/">HTML5</a>. 28 October 2014. REC. URL: <a href="http://www.w3.org/TR/html5/">http://www.w3.org/TR/html5/</a>
+   <dd>Ian Hickson; et al. <a href="http://www.w3.org/TR/html5/">HTML5</a>. 28 October 2014. REC. URL: <a href="http://www.w3.org/TR/html5/">http://www.w3.org/TR/html5/</a>
    <dt id="biblio-rfc2119"><a class="self-link" href="#biblio-rfc2119"></a>[RFC2119]
-   <dd>S. Bradner. <a href="http://www.ietf.org/rfc/rfc2119.txt">Key words for use in RFCs to Indicate Requirement Levels</a>. March 1997. Best Current Practice. URL: <a href="http://www.ietf.org/rfc/rfc2119.txt">http://www.ietf.org/rfc/rfc2119.txt</a>
+   <dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
    <dt id="biblio-workers"><a class="self-link" href="#biblio-workers"></a>[WORKERS]
    <dd>Ian Hickson. <a href="http://www.w3.org/TR/workers/">Web Workers</a>. 1 May 2012. CR. URL: <a href="http://www.w3.org/TR/workers/">http://www.w3.org/TR/workers/</a>
    <dt id="biblio-wsc-ui"><a class="self-link" href="#biblio-wsc-ui"></a>[WSC-UI]
@@ -1535,16 +1523,16 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
    <dd>Jenni Tennison. <a href="http://www.w3.org/TR/capability-urls/">Capability URLs</a>. WD. URL: <a href="http://www.w3.org/TR/capability-urls/">http://www.w3.org/TR/capability-urls/</a></dl>
   <h2 class="no-num heading settled" id="issues-index"><span class="content">Issues Index</span><a class="self-link" href="#issues-index"></a></h2>
   <div style="counter-reset:issue">
-   <div class="issue">If an <code><a data-link-type="element" href="http://www.w3.org/TR/html5/text-level-semantics.html#the-a-element">a</a></code>
-  or <code><a data-link-type="element" href="https://html.spec.whatwg.org/#the-area-element">area</a></code> element includes both
-  a <code>referrer</code> attribute as well as
+   <div class="issue"> If an <code><a data-link-type="element" href="http://www.w3.org/TR/html5/text-level-semantics.html#the-a-element">a</a></code>
+  or <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-area-element">area</a></code> element includes both
+  a <code>referrerpolicy</code> attribute as well as
   a <a href="https://html.spec.whatwg.org/#link-type-noreferrer"><code>noreferrer</code>
-  link type</a>, should the policy of the <code>referrer</code> attribute
+  link type</a>, should the policy of the <code>referrerpolicy</code> attribute
   take precedence over the link type, as suggested
   by <a href="https://lists.w3.org/Archives/Public/public-webappsec/2015Feb/0235.html">Martin
   Thomson</a>, or should we take the more conservative approach as suggested
   by <a href="https://lists.w3.org/Archives/Public/public-webappsec/2015Feb/0283.html">Brian
-  Smith</a> and honor the <code>noreferrer</code> link type?<a href="#issue-4ec1eba2"> ↵ </a></div>
-   <div class="issue">This algorithm needs to be modifed to take into account any local
+  Smith</a> and honor the <code>noreferrer</code> link type?<a href="#issue-a2e997ff"> ↵ </a></div>
+   <div class="issue"> This algorithm needs to be modifed to take into account any local
   overrides via the referrer attribute on elements.<a href="#issue-2cf94c0c"> ↵ </a></div></div></body>
 </html>

--- a/specs/referrer-policy/index.html
+++ b/specs/referrer-policy/index.html
@@ -71,7 +71,7 @@
    <h1 class="p-name no-ref" id="title">Referrer Policy</h1>
   
    <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft,
-    <time class="dt-updated" datetime="2015-07-22">22 July 2015</time></span></h2>
+    <time class="dt-updated" datetime="2015-07-27">27 July 2015</time></span></h2>
   
    <div data-fill-with="spec-metadata">
     <dl>
@@ -546,7 +546,7 @@
      
     
      <li>
-      Via a <code><a data-link-type="element" href="http://www.w3.org/TR/html5/document-metadata.html#the-meta-element">meta</a></code> element with a <code><a data-link-type="element-attr" href="http://www.w3.org/TR/html5/document-metadata.html#attr-meta-name">name</a></code> of <code>referrerpolicy</code>.
+      Via a <code><a data-link-type="element" href="http://www.w3.org/TR/html5/document-metadata.html#the-meta-element">meta</a></code> element with a <code><a data-link-type="element-attr" href="http://www.w3.org/TR/html5/document-metadata.html#attr-meta-name">name</a></code> of <code>referrer</code>.
     
      
     
@@ -790,6 +790,18 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
      
     
      <dd><a data-link-type="dfn" href="https://tools.ietf.org/html/rfc6454#section-3.2"><code>Origin</code></a>
+     
+    
+     <dt>no-referrer-when-downgrade
+     
+    
+     <dd><a data-link-type="dfn" href="#no-referrer-when-downgrade"><code>No Referrer When Downgrade</code></a>
+     
+    
+     <dt>origin-when-cross-origin
+     
+    
+     <dd><a data-link-type="dfn" href="#origin-when-cross_origin"><code>Origin When Cross-Origin</code></a>
      
     
      <dt>unsafe-url

--- a/specs/referrer-policy/index.html
+++ b/specs/referrer-policy/index.html
@@ -527,21 +527,28 @@
   ways:</p>
 
   
-    <ul>
+    <ol>
     
      <li>
       Via the <code>referrer</code> Content Security Policy directive (defined
-      in <a href="#directive-referrer">§4.1 Delivery via CSP</a>), delivered via the
-      <a href="https://w3c.github.io/webappsec/specs/content-security-policy/#content-security-policy-header-field"><code>Content-Security-Policy</code></a>
-      HTTP header. <a data-link-type="biblio" href="#biblio-csp2">[CSP2]</a>
-    
-     
-    
-     <li>
-      Via the <code>referrer</code> Content Security Policy directive (defined
-      in <a href="#directive-referrer">§4.1 Delivery via CSP</a>), delivered via a
-      <a href="https://w3c.github.io/webappsec/specs/content-security-policy/#delivery-html-meta-element"><code>&lt;meta></code> element</a>
-      <a data-link-type="biblio" href="#biblio-csp2">[CSP2]</a>
+      in <a href="#directive-referrer">§4.1 Delivery via CSP</a>), delivered in one of the following ways:
+      
+      <ul>
+        
+       <li>
+          Via the <a href="https://w3c.github.io/webappsec/specs/content-security-policy/#content-security-policy-header-field"><code>Content-Security-Policy</code></a>
+          HTTP header. <a data-link-type="biblio" href="#biblio-csp2">[CSP2]</a>
+        
+       
+        
+       <li>
+          Via the <a href="https://w3c.github.io/webappsec/specs/content-security-policy/#delivery-html-meta-element"><code>&lt;meta></code> element</a>
+          <a data-link-type="biblio" href="#biblio-csp2">[CSP2]</a>
+        
+       
+      
+      </ul>
+      
     
      
     
@@ -561,7 +568,7 @@
     
      
   
-    </ul>
+    </ol>
 
   
     <h3 class="heading settled" data-level="4.1" id="directive-referrer"><span class="secno">4.1. </span><span class="content">Delivery via CSP</span><a class="self-link" href="#directive-referrer"></a></h3>

--- a/specs/referrer-policy/index.html
+++ b/specs/referrer-policy/index.html
@@ -820,21 +820,17 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
     </dl>
 
 
-    <p>A policy delivered via a <code>referrerpolicy</code> attribute on an element
+    <p class="note" role="note">Note: A policy delivered via a <code>referrerpolicy</code> attribute on an element
   takes precedence over the policy defined for the whole document via CSP or
   a <a data-link-type="element" href="http://www.w3.org/TR/html5/document-metadata.html#the-meta-element">meta</a> element.</p>
 
 
-    <p class="issue" id="issue-a2e997ff"><a class="self-link" href="#issue-a2e997ff"></a> If an <code><a data-link-type="element" href="http://www.w3.org/TR/html5/text-level-semantics.html#the-a-element">a</a></code>
+    <p class="note" role="note">Note: If an <code><a data-link-type="element" href="http://www.w3.org/TR/html5/text-level-semantics.html#the-a-element">a</a></code>
   or <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-area-element">area</a></code> element includes both
   a <code>referrerpolicy</code> attribute as well as
-  a <a href="https://html.spec.whatwg.org/#link-type-noreferrer"><code>noreferrer</code>
-  link type</a>, should the policy of the <code>referrerpolicy</code> attribute
-  take precedence over the link type, as suggested
-  by <a href="https://lists.w3.org/Archives/Public/public-webappsec/2015Feb/0235.html">Martin
-  Thomson</a>, or should we take the more conservative approach as suggested
-  by <a href="https://lists.w3.org/Archives/Public/public-webappsec/2015Feb/0283.html">Brian
-  Smith</a> and honor the <code>noreferrer</code> link type?</p>
+  a <a data-link-type="dfn" href="http://www.w3.org/TR/html5/links.html#link-type-noreferrer"><code>noreferrer</code></a> link type then the <a data-link-type="dfn" href="http://www.w3.org/TR/html5/links.html#link-type-noreferrer"><code>noreferrer</code></a>
+  link type will take precedence and the <a data-link-type="dfn" href="#no-referrer"><code>No Referrer</code></a> policy
+  takes effect.</p>
 
   
     <h3 class="heading settled" data-level="4.4" id="referrer-policy-delivery-implicit"><span class="secno">4.4. </span><span class="content">Implicit Delivery</span><a class="self-link" href="#referrer-policy-delivery-implicit"></a></h3>
@@ -1542,16 +1538,6 @@ directive-value   = "no-referrer" / "no-referrer-when-downgrade" / "origin" / "o
    <dd>Jenni Tennison. <a href="http://www.w3.org/TR/capability-urls/">Capability URLs</a>. WD. URL: <a href="http://www.w3.org/TR/capability-urls/">http://www.w3.org/TR/capability-urls/</a></dl>
   <h2 class="no-num heading settled" id="issues-index"><span class="content">Issues Index</span><a class="self-link" href="#issues-index"></a></h2>
   <div style="counter-reset:issue">
-   <div class="issue"> If an <code><a data-link-type="element" href="http://www.w3.org/TR/html5/text-level-semantics.html#the-a-element">a</a></code>
-  or <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-area-element">area</a></code> element includes both
-  a <code>referrerpolicy</code> attribute as well as
-  a <a href="https://html.spec.whatwg.org/#link-type-noreferrer"><code>noreferrer</code>
-  link type</a>, should the policy of the <code>referrerpolicy</code> attribute
-  take precedence over the link type, as suggested
-  by <a href="https://lists.w3.org/Archives/Public/public-webappsec/2015Feb/0235.html">Martin
-  Thomson</a>, or should we take the more conservative approach as suggested
-  by <a href="https://lists.w3.org/Archives/Public/public-webappsec/2015Feb/0283.html">Brian
-  Smith</a> and honor the <code>noreferrer</code> link type?<a href="#issue-a2e997ff"> ↵ </a></div>
    <div class="issue"> This algorithm needs to be modifed to take into account any local
   overrides via the referrer attribute on elements.<a href="#issue-2cf94c0c"> ↵ </a></div></div></body>
 </html>

--- a/specs/referrer-policy/index.src.html
+++ b/specs/referrer-policy/index.src.html
@@ -376,10 +376,10 @@ spec: RFC7231; urlPrefix: https://tools.ietf.org/html/rfc7231
       [[!CSP2]]
     </li>
     <li>
-      Via a <{meta}> element with a <{meta/name}> of <code>referrer</code>.
+      Via a <{meta}> element with a <{meta/name}> of <code>referrerpolicy</code>.
     </li>
     <li>
-      Via a <code>referrer</code> attribute on an <{a}>, <{area}>, <{img}>
+      Via a <code>referrerpolicy</code> attribute on an <{a}>, <{area}>, <{img}>
       or <{iframe}> element.
     </li>
     <li>
@@ -516,18 +516,18 @@ spec: RFC7231; urlPrefix: https://tools.ietf.org/html/rfc7231
   </dl>
 
   <h3 id="referrer-policy-delivery-referrer-attribute">Delivery
-  via a <code>referrer</code> attribute</h3>
+  via a <code>referrerpolicy</code> attribute</h3>
 
-  A referrer policy may be set when a <code>referrer</code> attribute is
+  A referrer policy may be set when a <code>referrerpolicy</code> attribute is
   added to an <code><a element>a</a></code>, <code><a element>area</a></code>,
   <code><a element>img</a></code> or <code><a element>iframe</a></code>
   element, for example:
 
   <pre class="example">
-    &lt;a href="http://example.com" referrer="origin"&gt;
+    &lt;a href="http://example.com" referrerpolicy="origin"&gt;
   </pre>
 
-  The following values for the <code>referrer</code> attribute are valid,
+  The following values for the <code>referrerpolicy</code> attribute are valid,
   and map to the listed <a>referrer policy</a> values:
 
   <dl>
@@ -539,15 +539,15 @@ spec: RFC7231; urlPrefix: https://tools.ietf.org/html/rfc7231
     <dd><a><code>Unsafe URL</code></a></dd>
   </dl>
 
-  A policy delivered via a <code>referrer</code> attribute on an element
+  A policy delivered via a <code>referrerpolicy</code> attribute on an element
   takes precedence over the policy defined for the whole document via CSP or
   a <a element>meta</a> element.
 
   ISSUE: If an <code><a element>a</a></code>
   or <code><a element>area</a></code> element includes both
-  a <code>referrer</code> attribute as well as
+  a <code>referrerpolicy</code> attribute as well as
   a <a href="https://html.spec.whatwg.org/#link-type-noreferrer"><code>noreferrer</code>
-  link type</a>, should the policy of the <code>referrer</code> attribute
+  link type</a>, should the policy of the <code>referrerpolicy</code> attribute
   take precedence over the link type, as suggested
   by <a href="https://lists.w3.org/Archives/Public/public-webappsec/2015Feb/0235.html">Martin
   Thomson</a>, or should we take the more conservative approach as suggested

--- a/specs/referrer-policy/index.src.html
+++ b/specs/referrer-policy/index.src.html
@@ -362,18 +362,20 @@ spec: RFC7231; urlPrefix: https://tools.ietf.org/html/rfc7231
   A <a>settings object</a>'s <a>referrer policy</a> is delivered in one of four
   ways:
 
-  <ul>
+  <ol>
     <li>
       Via the <code>referrer</code> Content Security Policy directive (defined
-      in [[#directive-referrer]]), delivered via the
-      <a href="https://w3c.github.io/webappsec/specs/content-security-policy/#content-security-policy-header-field"><code>Content-Security-Policy</code></a>
-      HTTP header. [[!CSP2]]
-    </li>
-    <li>
-      Via the <code>referrer</code> Content Security Policy directive (defined
-      in [[#directive-referrer]]), delivered via a
-      <a href="https://w3c.github.io/webappsec/specs/content-security-policy/#delivery-html-meta-element"><code>&lt;meta&gt;</code> element</a>
-      [[!CSP2]]
+      in [[#directive-referrer]]), delivered in one of the following ways:
+      <ul>
+        <li>
+          Via the <a href="https://w3c.github.io/webappsec/specs/content-security-policy/#content-security-policy-header-field"><code>Content-Security-Policy</code></a>
+          HTTP header. [[!CSP2]]
+        </li>
+        <li>
+          Via the <a href="https://w3c.github.io/webappsec/specs/content-security-policy/#delivery-html-meta-element"><code>&lt;meta&gt;</code> element</a>
+          [[!CSP2]]
+        </li>
+      </ul>
     </li>
     <li>
       Via a <{meta}> element with a <{meta/name}> of <code>referrer</code>.
@@ -385,7 +387,7 @@ spec: RFC7231; urlPrefix: https://tools.ietf.org/html/rfc7231
     <li>
       Implicitly, via inheritance.
     </li>
-  </ul>
+  </ol>
 
   <h3 id="directive-referrer">Delivery via CSP</h3>
 

--- a/specs/referrer-policy/index.src.html
+++ b/specs/referrer-policy/index.src.html
@@ -545,20 +545,16 @@ spec: RFC7231; urlPrefix: https://tools.ietf.org/html/rfc7231
     <dd><a><code>Unsafe URL</code></a></dd>
   </dl>
 
-  A policy delivered via a <code>referrerpolicy</code> attribute on an element
+  Note: A policy delivered via a <code>referrerpolicy</code> attribute on an element
   takes precedence over the policy defined for the whole document via CSP or
   a <a element>meta</a> element.
 
-  ISSUE: If an <code><a element>a</a></code>
+  Note: If an <code><a element>a</a></code>
   or <code><a element>area</a></code> element includes both
   a <code>referrerpolicy</code> attribute as well as
-  a <a href="https://html.spec.whatwg.org/#link-type-noreferrer"><code>noreferrer</code>
-  link type</a>, should the policy of the <code>referrerpolicy</code> attribute
-  take precedence over the link type, as suggested
-  by <a href="https://lists.w3.org/Archives/Public/public-webappsec/2015Feb/0235.html">Martin
-  Thomson</a>, or should we take the more conservative approach as suggested
-  by <a href="https://lists.w3.org/Archives/Public/public-webappsec/2015Feb/0283.html">Brian
-  Smith</a> and honor the <code>noreferrer</code> link type?
+  a <a><code>noreferrer</code></a> link type then the <a><code>noreferrer</code></a>
+  link type will take precedence and the <a><code>No Referrer</code></a> policy
+  takes effect.
 
   <h3 id="referrer-policy-delivery-implicit">Implicit Delivery</h3>
 

--- a/specs/referrer-policy/index.src.html
+++ b/specs/referrer-policy/index.src.html
@@ -376,7 +376,7 @@ spec: RFC7231; urlPrefix: https://tools.ietf.org/html/rfc7231
       [[!CSP2]]
     </li>
     <li>
-      Via a <{meta}> element with a <{meta/name}> of <code>referrerpolicy</code>.
+      Via a <{meta}> element with a <{meta/name}> of <code>referrer</code>.
     </li>
     <li>
       Via a <code>referrerpolicy</code> attribute on an <{a}>, <{area}>, <{img}>
@@ -535,6 +535,10 @@ spec: RFC7231; urlPrefix: https://tools.ietf.org/html/rfc7231
     <dd><a><code>No Referrer</code></a></dd>
     <dt>origin</dt>
     <dd><a><code>Origin</code></a></dd>
+    <dt>no-referrer-when-downgrade</dt>
+    <dd><a><code>No Referrer When Downgrade</code></a></dd>
+    <dt>origin-when-cross-origin</dt>
+    <dd><a><code>Origin When Cross-Origin</code></a></dd>
     <dt>unsafe-url</dt>
     <dd><a><code>Unsafe URL</code></a></dd>
   </dl>


### PR DESCRIPTION
@annevk @jeisinger this is an attempt to address the comments regarding renaming "referrer" to "referrerpolicy" as discussed in https://github.com/w3c/webappsec/issues/409

I see there are other changes being added but I only did a "make referrer-policy/index.html" so maybe that is expected?

/cc @wooseok