### PR TITLE
Explore automatic publication with Travis & Echidna

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ script:
  - bikeshed spec ./upgrade/index.src.html
 env:
   global:
-    - URL="https://w3c.github.io/webappsec/specs/content-security-policy/echidna-manifest-mixed-content.txt"
+    - URL="https://w3c.github.io/webappsec/echidna-manifest-mixed-content.txt"
     - DECISION="[TO-DO]"
     - secure: "[TO-DO run: 'gem install travis; travis encrypt TOKEN=<the-token>']"
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+language: python
+python:
+ - "2.7"
+before_install:
+ - sudo apt-get update -qq
+ - sudo apt-get install -qq python-dev python-pip libxslt1-dev libxml2-dev
+ - sudo pip install pygments
+install:
+ - git clone --depth=1 --branch=master https://github.com/tabatkins/bikeshed.git ./bikeshed
+ - sudo pip install --editable ./bikeshed
+ - bikeshed update
+script:
+ - cd specs
+ - bikeshed spec ./credentialmanagement/index.src.html
+ - bikeshed spec ./csp-pinning/index.src.html
+ - bikeshed spec ./powerfulfeatures/index.src.html
+ - bikeshed spec ./content-security-policy/index.src.html
+ - bikeshed spec ./CSP2/index.src.html
+ - bikeshed spec ./mixedcontent/index.src.html
+ - bikeshed spec ./referrer-policy/index.src.html
+ - bikeshed spec ./upgrade/index.src.html
+env:
+  global:
+    - URL="https://w3c.github.io/webappsec/specs/content-security-policy/echidna-manifest-mixed-content.txt"
+    - DECISION="[TO-DO]"
+    - secure: "[TO-DO run: 'gem install travis; travis encrypt TOKEN=<the-token>']"
+after_success:
+  - curl "https://labs.w3.org/echidna/api/request" --data "url=$URL" --data "decision=$DECISION" --data "token=$TOKEN"

--- a/echidna-manifest-CSP2.txt
+++ b/echidna-manifest-CSP2.txt
@@ -1,3 +1,3 @@
 # Manifest file for Echidna (automatic publication).
 # [TO-DO: add all necessary files here if there are more -- one per line after the main one.]
-specs/content-security-policy/index.html?specStatus=WD;shortName=CSP2 respec
+[URL-to-processed-WD-generated-by-Bikeshed]

--- a/echidna-manifest-CSP2.txt
+++ b/echidna-manifest-CSP2.txt
@@ -1,0 +1,3 @@
+# Manifest file for Echidna (automatic publication).
+# [TO-DO: add all necessary files here if there are more -- one per line after the main one.]
+specs/content-security-policy/index.html?specStatus=WD;shortName=CSP2 respec

--- a/echidna-manifest-credential-management.txt
+++ b/echidna-manifest-credential-management.txt
@@ -1,0 +1,3 @@
+# Manifest file for Echidna (automatic publication).
+# [TO-DO: add all necessary files here if there are more -- one per line after the main one.]
+specs/credentialmanagement/index.html?specStatus=WD;shortName=credential-management respec

--- a/echidna-manifest-credential-management.txt
+++ b/echidna-manifest-credential-management.txt
@@ -1,3 +1,3 @@
 # Manifest file for Echidna (automatic publication).
 # [TO-DO: add all necessary files here if there are more -- one per line after the main one.]
-specs/credentialmanagement/index.html?specStatus=WD;shortName=credential-management respec
+[URL-to-processed-WD-generated-by-Bikeshed]

--- a/echidna-manifest-mixed-content.txt
+++ b/echidna-manifest-mixed-content.txt
@@ -1,0 +1,3 @@
+# Manifest file for Echidna (automatic publication).
+# [TO-DO: add all necessary files here if there are more -- one per line after the main one.]
+specs/mixedcontent/index.html?specStatus=WD;shortName=mixed-content respec

--- a/echidna-manifest-mixed-content.txt
+++ b/echidna-manifest-mixed-content.txt
@@ -1,3 +1,3 @@
 # Manifest file for Echidna (automatic publication).
 # [TO-DO: add all necessary files here if there are more -- one per line after the main one.]
-specs/mixedcontent/index.html?specStatus=WD;shortName=mixed-content respec
+[URL-to-processed-WD-generated-by-Bikeshed]


### PR DESCRIPTION
This is an incomplete attempt to get WDs here to be automatically published using [Echidna](https://github.com/w3c/echidna/wiki). There are a few issues to get this done right now.

**Changes:**
* Added Echidna manifest files for three of the specs here (as samples or templates): [content security policy](https://w3c.github.io/webappsec/specs/content-security-policy/), [credential management level 1](https://w3c.github.io/webappsec/specs/credentialmanagement/) and [mixed content](https://w3c.github.io/webappsec/specs/mixedcontent/).
* Added some lines to Travis config file, trying to illustrate how the *content security policy* WD could be set up with Travis/Echidna; there is necessary data missing.

**What's missing:**

* Collect all the URLs of the group's decisions to publish each spec, and set them up with Travis/Echidna.
* [Get a token](https://github.com/w3c/echidna/wiki/Token-creation) for each spec.
* Encrypt the tokens with Travis and set the resulting strings up with Travis/Echidna ([instructions](https://github.com/w3c/echidna/wiki/Setting-up-Echidna-as-a-GitHub-hook)).
* For WDs that are made up of more files than the index HTML, list all those files in additional lines in their manifests.

**Notes:**
* As it is now, Travis would publish *all* WDs every time there's a commit/tag/branch. Some ideas to solve that, off the top of my head:
  * Split this repo in several repos; one per spec, like other WGs do (recommended).
  * Write a custom script that would invoke Echidna to publish only the right spec (the one where there has been a commit etc), and use that in the `script` section of the Travis config file.
* Echidna expects [W3C IDs for all editors](https://github.com/w3c/echidna/wiki/Preparing-your-document#data-editor-id). This is easy to add when using spec-generator; I don't know about Bikeshed.
* Echidna needs to retrieve *a WD* (not an ED) from *a public URL*; as it is now, this group would need a public instance of Bikeshed to spit out that WD for Echidna.

--
@sideshowbarker, @mikewest: ping! :)