### PR TITLE
Update date and status of Web Workers

### DIFF
--- a/specs/upgrade/published/2015-09-CR.html
+++ b/specs/upgrade/published/2015-09-CR.html
@@ -993,7 +993,7 @@ Location: https://example.com/
    <dt id="biblio-rfc7240"><a class="self-link" href="#biblio-rfc7240"></a>[RFC7240]
    <dd>J. Snell. <a href="https://tools.ietf.org/html/rfc7240">Prefer Header for HTTP</a>. June 2014. Proposed Standard. URL: <a href="https://tools.ietf.org/html/rfc7240">https://tools.ietf.org/html/rfc7240</a>
    <dt id="biblio-workers"><a class="self-link" href="#biblio-workers"></a>[WORKERS]
-   <dd>Ian Hickson. <a href="http://www.w3.org/TR/workers/">Web Workers</a>. 1 May 2012. CR. URL: <a href="http://www.w3.org/TR/workers/">http://www.w3.org/TR/workers/</a>
+   <dd>Ian Hickson. <a href="http://www.w3.org/TR/workers/">Web Workers</a>. 24 September 2015. WD. URL: <a href="http://www.w3.org/TR/workers/">http://www.w3.org/TR/workers/</a>
   </dl>
   <h3 class="no-num heading settled" id="informative"><span class="content">Informative References</span><a class="self-link" href="#informative"></a></h3>
   <dl>


### PR DESCRIPTION
This PR changes the Web Workers reference from the 2012 CR to the WD published on 24 September 2015.