### PR TITLE
Mark plugin-types as a non-default source

### DIFF
--- a/specs/content-security-policy/index.html
+++ b/specs/content-security-policy/index.html
@@ -1841,6 +1841,8 @@ directive-value   = <a data-link-type="dfn" href="#media_type_list">media-type-l
      <p>Whenever the user agent creates a <a data-link-type="dfn" href="http://www.w3.org/TR/html5/browsers.html#plugin-document">plugin document</a> as the <a data-link-type="dfn" href="http://www.w3.org/TR/html5/browsers.html#active-document">active document</a> of a <a data-link-type="dfn" href="http://www.w3.org/TR/html5/browsers.html#child-browsing-context">child browsing context</a> of the <a data-link-type="dfn" href="#protected-resource">protected resource</a>, if the user agent is monitoring any <code>plugin-types</code> directives for the protected resource, the user
     agent MUST <a data-link-type="dfn" href="#monitor">monitor</a> those <code>plugin-types</code> directives on the
     plugin document as well.</p>
+    <p class="note" role="note">Note: <code>plugin-types</code> does not fall back to the <a data-link-type="dfn" href="#default-sources">default
+    sources</a>.</p>
      <section class="informative">
       <h4 class="heading settled" data-level="7.13.1" id="plugin-types-usage"><span class="secno">7.13.1. </span><span class="content">Usage</span><a class="self-link" href="#plugin-types-usage"></a></h4>
       <p><em>This section is not normative.</em></p>


### PR DESCRIPTION
I'm not sure if this is correct, but I think plugin-types does not inherit from `default-src`. 

/cc @mikewest 