### PR TITLE
Make redirect for SRI spec include fragment ID

### DIFF
--- a/specs/subresourceintegrity/index.html
+++ b/specs/subresourceintegrity/index.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <meta http-equiv="refresh" content="0; url=https://w3c.github.io/webappsec-subresource-integrity/">
   <meta charset="utf-8">
   <title>Subresource Integrity</title>
   <script src='https://www.w3.org/Tools/respec/respec-w3c-common' class='remove'></script>
@@ -122,7 +121,7 @@
     };
   </script>
 </head>
-<body>
+<body onload='(function() { location.href = "https://w3c.github.io/webappsec-subresource-integrity/" + location.hash; })()'>
 <section id="abstract">
   <p>This specification defines a mechanism by which user agents may verify that
 a fetched resource has been delivered without unexpected manipulation.</p>


### PR DESCRIPTION
This change makes the specs/subresourceintegrity/index.html file’s in-document redirect include any fragment ID in the target URL the request gets redirected to. That prevents any existing links like https://w3c.github.io/webappsec/specs/subresourceintegrity/#HTMLLinkElement (in, eg., MDN articles) from otherwise breaking.