### PR TITLE
[charter 2021] allow going to rec; require 2x expected support

### DIFF
--- a/admin/webappsec-charter-2021.html
+++ b/admin/webappsec-charter-2021.html
@@ -556,7 +556,7 @@
 	  <h2>Success Criteria</h2>
 	  <p>In order to advance to <a href="https://www.w3.org/Consortium/Process/#RecsPR" title="Proposed Recommendation">Proposed Recommendation</a>, each normative specification is expected to have <a href="https://www.w3.org/Consortium/Process/#implementation-experience">at least two independent implementations</a> of every feature defined in the specification.</p>
 	  <p>Each specification should contain separate sections detailing all known security and privacy implications for implementers, Web authors, and end users.</p>
-  	  <p>All new features should be supported by at least two intents to implement before being incorporated in the specification.</p>
+  	  <p>New features should be expected to be supported by at least two implementations, which may be judged by factors including existing implementations, expressions of interest, and lack of opposition.</p>
 	  <p>There should be testing plans for each specification, starting from the earliest drafts.</p>
 	  <p>
 		Each specification should contain a section on

--- a/admin/webappsec-charter-2021.html
+++ b/admin/webappsec-charter-2021.html
@@ -255,15 +255,16 @@
           Deliverables
         </h2>
 
-        <p>More detailed milestones and updated publication schedules are available on the <a href="https://www.w3.org/groups/wg/webappsec/publications">group publication status page</a>.</p>
-
-	<p><i>Draft state</i> indicates the state of the deliverable
+	<p><i>Draft state</i>, below, indicates the state of the deliverable
 	at the time of the charter approval.</p>
 
+	<p>Current document status is available on the <a href="https://www.w3.org/groups/wg/webappsec/publications">group publication status page</a>.</p>
+	      
 	<p>With the exception of the Mixed Content specification, the
 	  Working Group intends to publish the latest state of their
-	  work as Candidate Recommendation (with Snapshots) and does
-	  not intend to advance their documents to Recommendation.</p>
+	  work as Candidate Recommendation (with Snapshots) and may advance
+	  documents when Recommendation when they are sufficiently mature,
+	  with no explicit milestones.</p>
 	
         <section id="normative">
           <h3>
@@ -555,6 +556,7 @@
 	  <h2>Success Criteria</h2>
 	  <p>In order to advance to <a href="https://www.w3.org/Consortium/Process/#RecsPR" title="Proposed Recommendation">Proposed Recommendation</a>, each normative specification is expected to have <a href="https://www.w3.org/Consortium/Process/#implementation-experience">at least two independent implementations</a> of every feature defined in the specification.</p>
 	  <p>Each specification should contain separate sections detailing all known security and privacy implications for implementers, Web authors, and end users.</p>
+  	  <p>All new features should be supported by at least two intents to implement before being incorporated in the specification.</p>
 	  <p>There should be testing plans for each specification, starting from the earliest drafts.</p>
 	  <p>
 		Each specification should contain a section on

--- a/admin/webappsec-charter-2021.html
+++ b/admin/webappsec-charter-2021.html
@@ -262,7 +262,7 @@
 	      
 	<p>With the exception of the Mixed Content specification, the
 	  Working Group intends to publish the latest state of their
-	  work as Candidate Recommendation (with Snapshots). The group may advance
+	  work as Candidate Recommendation (with Snapshots). The group will advance
 	  documents to Recommendation when they are sufficiently mature,
 	  with no explicit milestones.</p>
 	

--- a/admin/webappsec-charter-2021.html
+++ b/admin/webappsec-charter-2021.html
@@ -262,8 +262,8 @@
 	      
 	<p>With the exception of the Mixed Content specification, the
 	  Working Group intends to publish the latest state of their
-	  work as Candidate Recommendation (with Snapshots) and may advance
-	  documents when Recommendation when they are sufficiently mature,
+	  work as Candidate Recommendation (with Snapshots). The group may advance
+	  documents to Recommendation when they are sufficiently mature,
 	  with no explicit milestones.</p>
 	
         <section id="normative">


### PR DESCRIPTION
per discussions on 20 April 2021 WG call: https://github.com/w3c/webappsec/blob/main/meetings/2021/2021-04-20-minutes.md