### PR TITLE
Set 2021 milestone for mixed content to Rec

### DIFF
--- a/admin/webappsec-charter-2021.html
+++ b/admin/webappsec-charter-2021.html
@@ -262,11 +262,10 @@
 
 	<p>Current document status is available on the <a href="https://www.w3.org/groups/wg/webappsec/publications">group publication status page</a>.</p>
 	      
-	<p>With the exception of the Mixed Content specification, the
-	  Working Group intends to publish the latest state of their
-	  work as Candidate Recommendation (with Snapshots). The group will advance additional
-	  documents to Recommendation when they are sufficiently mature,
-	  with no explicit milestones.</p>
+	<p>The Working Group intends to publish the Mixed Content specification as
+	a Recommendation before the end of 2021. The group will advance
+	its other documents to Candidate Recommendation (with Snapshots) and, when they are
+	sufficiently mature, to Recommendation, with no explicit milestones.</p>
 	
         <section id="normative">
           <h3>


### PR DESCRIPTION
a suggestion from @plehegar. 

n.b., we may also be setting some milestones for some other specs, so the remaining rewrite of this paragraph may be overtaken by events.