### PR TITLE
[charter] typos/clarity

### DIFF
--- a/admin/webappsec-charter-2021.html
+++ b/admin/webappsec-charter-2021.html
@@ -214,7 +214,7 @@
 	    features of the Web have evolved, providing uniformly
 	    secure experiences to users is difficult for
 	    developers. The Working Group will document and create uniform
-	    experiences for several undefined areas of major utility,
+	    experiences for several areas of major utility,
 	    including:</p>
 	    <ul>
 	      <li>Providing hinting and direct support for credential
@@ -431,7 +431,7 @@
           <p>A standardized API to address use cases
           related to assisted management of user credentials, including traditional
           username/password pairs, username/federated identity provider pairs. The API should allow
-          for explicit and interoperable imperative mechanism for use and lifecycle management of
+          for explicit and interoperable imperative mechanisms for use and lifecycle management of
           these common credential types.</p>
 
           <p class="draft-status"><b>Draft state:</b> <a href=


### PR DESCRIPTION
in response to AC review, saying:

> 
> In the Scope section, "principals" should be "principles".
> 
> In the Credential Management API section, should "allow for explicit and interoperable imperative mechanism" be "allow for an ..." or "... mechanisms"?
> 
> In the Subresource Integrity Level 2 section, there's a typo in "taggging", and "web applications units" should be "web applications" or "web application units".
> 
> Also, what does "undefined" mean in "several undefined areas of major utility"? The list that follows seems to provide some definition.