### PR TITLE
Add Secure Curves in Web Crypto to meeting agenda

### DIFF
--- a/meetings/2022/2022-06-15-agenda.md
+++ b/meetings/2022/2022-06-15-agenda.md
@@ -8,6 +8,7 @@
     *   Our slots are tentatively Monday 4pm-6pm, Tuesday 9am-11am and 4pm-6pm
 *   CSP ['wasm-unsafe-eval'](https://w3c.github.io/webappsec-csp/#wasm-integration)
 *   CfC to Publish [Permission Registry](https://w3c.github.io/permissions-registry/) as a Draft Registry
+*   [Secure Curves in Web Crypto](https://wicg.github.io/webcrypto-secure-curves/) ([Daniel Huigens](https://github.com/twiss))
 
 If you would like to add an item to the agenda, please open a PR against [this document](https://github.com/w3c/webappsec/new/main/meetings/2022/2022-06-15-agenda.md)
 


### PR DESCRIPTION
Hey :wave: Given that the new charter was adopted and [Secure Curves in Web Crypto](https://wicg.github.io/webcrypto-secure-curves/) is now a WICG draft (though not "well-supported" yet), can we add an agenda item for this?

I can give a brief overview of what the spec says, if it's useful, and would like to highlight some remaining open questions and field comments.