### PR TITLE
Comments from PING on charter 2024

### DIFF
--- a/admin/webappsec-charter-2023.html
+++ b/admin/webappsec-charter-2023.html
@@ -468,7 +468,6 @@
       
                 <p class="draft-status"><b>Draft state:</b> <a href=
                 "https://www.w3.org/TR/2016/WD-credential-management-1-20160425/">Working Draft</a></p>
-            <p><b>Expected publication as a Candidate Recommendation:</b> No later than <span class='todo'>Q2 2022</span></p>	
       
                     <p><b>Exclusion Draft:</b> <a href="https://www.w3.org/TR/2015/WD-credential-management-1-20150430/">30 April 2015</a>
               <p><b>Other Charter:</b> <a href="https://www.w3.org/2015/03/webappsec-charter-2015.html">2015 charter</a></p>
@@ -488,7 +487,6 @@
                       features.
                     </p>
                     <p class="draft-status"><b>Draft state:</b> <a href="https://www.w3.org/TR/2020/WD-permissions-20200720/">Working Draft</a></p>
-              <p><b>Expected publication as a Candidate Recommendation:</b> No later than <span class='todo'>Q2 2022</span></p>	
                     <p><b>Exclusion Draft:</b> <a href="https://www.w3.org/TR/2015/WD-permissions-20150407/">7 April 2015</a></p>
               <p><b>Other Charter:</b> <a href="https://www.w3.org/2015/03/webappsec-charter-2015.html">2015 charter</a></p>
             </dd>
@@ -500,7 +498,6 @@
           APIs.  Formerly known as Feature Policy.
               </p>
                     <p  class="draft-status"><b>Draft state:</b> Adopted from WICG</p>
-              <p><b>Expected publication as a Candidate Recommendation:</b> No later than <span class='todo'>Q2 2022</span></p>	
               </dd>
             
             

--- a/admin/webappsec-charter-2023.html
+++ b/admin/webappsec-charter-2023.html
@@ -468,7 +468,7 @@
       
                 <p class="draft-status"><b>Draft state:</b> <a href=
                 "https://www.w3.org/TR/2016/WD-credential-management-1-20160425/">Working Draft</a></p>
-            <p><b>Expected publication as a Candidate Recommendation:</b> No later than Q2 2022</p>	
+            <p><b>Expected publication as a Candidate Recommendation:</b> No later than <span class='todo'>Q2 2022</span></p>	
       
                     <p><b>Exclusion Draft:</b> <a href="https://www.w3.org/TR/2015/WD-credential-management-1-20150430/">30 April 2015</a>
               <p><b>Other Charter:</b> <a href="https://www.w3.org/2015/03/webappsec-charter-2015.html">2015 charter</a></p>
@@ -488,7 +488,7 @@
                       features.
                     </p>
                     <p class="draft-status"><b>Draft state:</b> <a href="https://www.w3.org/TR/2020/WD-permissions-20200720/">Working Draft</a></p>
-              <p><b>Expected publication as a Candidate Recommendation:</b> No later than Q2 2022</p>	
+              <p><b>Expected publication as a Candidate Recommendation:</b> No later than <span class='todo'>Q2 2022</span></p>	
                     <p><b>Exclusion Draft:</b> <a href="https://www.w3.org/TR/2015/WD-permissions-20150407/">7 April 2015</a></p>
               <p><b>Other Charter:</b> <a href="https://www.w3.org/2015/03/webappsec-charter-2015.html">2015 charter</a></p>
             </dd>
@@ -500,7 +500,7 @@
           APIs.  Formerly known as Feature Policy.
               </p>
                     <p  class="draft-status"><b>Draft state:</b> Adopted from WICG</p>
-              <p><b>Expected publication as a Candidate Recommendation:</b> No later than Q2 2022</p>	
+              <p><b>Expected publication as a Candidate Recommendation:</b> No later than <span class='todo'>Q2 2022</span></p>	
               </dd>
             
             

--- a/admin/webappsec-charter-2023.html
+++ b/admin/webappsec-charter-2023.html
@@ -700,6 +700,12 @@
 
             <dt><a href="https://www.w3.org/das/">Devices and Sensors Working Group</a></dt>
             <dd>The WG may work with the Devices and Sensors WG on the security of their client-side APIs.</dd>
+
+            <dt><a href="https://www.w3.org/groups/ig/privacy/">Privacy Interest Group</a></dt>
+            <dd>
+              The work on Security and privacy model for cookies, Permissions best practices and APIs,
+              and End-to-End Encryption email should be coordinated with the Privacy group.
+            </dd>
           </dl>
 
         </section>


### PR DESCRIPTION
Address [coordination with PING](https://github.com/w3c/strategy/issues/426#issuecomment-1785698970).

Timelines in 2022 should be removed or updated.
