### PR TITLE
Update 2025-01-15-agenda.md

### DIFF
--- a/meetings/2025/2025-01-15-agenda.md
+++ b/meetings/2025/2025-01-15-agenda.md
@@ -6,6 +6,7 @@
 *   [Signature-based Integrity](https://wicg.github.io/signature-based-sri/) updates (@mikewest)
     *   In particular, forward-compat concerns in WICG/signature-based-sri#38.  
 *   [`Timing-Allow-Origin` guidelines](https://github.com/w3c/webappsec/issues/664)?
+*   CSP script-src [`trusted-types-eval`](https://github.com/w3c/webappsec-csp/pull/665) keyword addition.
 
 If you would like to add an item to the agenda, please open a PR against [this document](https://github.com/w3c/webappsec/new/main/meetings/2025/2025-01-15-agenda.md)
 


### PR DESCRIPTION
Add https://github.com/w3c/webappsec-csp/pull/665 to agenda to try and get it across the line.