### PR TITLE
Update 2026-06-10 Agenda: TPAC 2026 Room for WebAppSec

### DIFF
--- a/meetings/2026/2026-06-10-agenda.md
+++ b/meetings/2026/2026-06-10-agenda.md
@@ -11,6 +11,7 @@
   - [HPKE](https://github.com/WICG/webcrypto-modern-algos/issues/2) (issue)
 * [Web Threat Model](https://w3c.github.io/threat-model-web/) (@simoneonofri)
 * [CSP: Embedded Enforcement](https://w3c.github.io/webappsec-cspee/) updates, time permitting (@mikewest)
+* [TPAC 2026](https://github.com/w3c/tpac2026-meetings/), booking the meeting room
 
 If you would like to add an item to the agenda, please open a PR against [this document](https://github.com/w3c/webappsec/blob/main/meetings/2026/2026-06-10-agenda.md)
 


### PR DESCRIPTION
TPAC 2026 will take place from 26-30 October 2026
with in-person meetings at Clayton Hotel Burlington Road in Dublin, Ireland.

As usual, we will organize group meetings (including joint meetings)
on Monday, Tuesday, Thursday, and Friday. 

We have to decide 17 June at the latest.